### PR TITLE
✨ More project-related commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `ProjectInit`, `ProjectTest`, `ProjectLint`, `ProjectDependenciesCheck`, and `ProjectSecurityCheck` workspace functions.
+- Implement `ProjectInit` for Causa workspaces.
+
 ## v0.6.0 (2023-06-01)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This repository contains the source code for the `@causa/workspace-core` Causa module. It provides the implementations of many `cs` commands. It also provides definitions for commands that are meant to be implemented by other modules, depending on the project types and/or languages. For more information about the Causa CLI `cs`, checkout [its repository](https://github.com/causa-io/cli).
 
-# Installation
+## 🎉 Installation
 
 Add `@causa/workspace-core` to your Causa configuration in `causa.modules`.
 
-# Configuration
+## 🔧 Configuration
 
 Several configurations are defined in this module, first for some generic `project.type`s:
 
@@ -16,19 +16,20 @@ Several configurations are defined in this module, first for some generic `proje
 
 This modules also exposes the [`DockerConfiguration`](./src/configurations/docker.ts), which is used by the `DockerService`, exposing usual Docker commands.
 
-# Supported project types and commands
+## ✨ Supported project types and commands
 
 The core module defines and implements many base `cs` commands. As a Causa user, you may want to check the [CLI repository](https://github.com/causa-io/cli) instead. As a module developer, you may want to check the [definitions](./src/definitions/) and determine which ones are relevant to implement in your module.
 
-## Commands
+### Commands
 
+- `cs init`: Initializes the workspace. This is a no-op in most cases as the CLI takes care of bootstrapping the workspace before running. The core module does not provide any project-specific implementation.
 - `cs emulators`: Provides the `list`, `start`, and `stop` commands. However no actual emulator is implemented by this module. Available emulators will depend on other loaded modules.
 - `cs environment`: Provides the `prepare` and `deploy` commands, forwarding those infrastructure commands to the project configured in `infrastructure.environmentProject`.
 - `cs events generateCode`: Lists the event topics used by the current project (based on its type) and triggers the generation of the corresponding types. The actual code generation depends on the programming language and should be implemented in the relevant modules.
 - `cs infrastructure`: Provides the `prepare` and `deploy` commands. Those commands run "infrastructure processors" before the actual infrastructure operation, and tear those down afterwards. The core module does not implement actual infrastructure operations, which depend on the project's language, e.g. `terraform`.
 - `cs publish`: While many base commands (e.g. `cs build`) are straightforward and should be implemented by the modules handling the corresponding project types and languages, `cs publish` provides some logic around these base commands to both build and push a project's artefact. The artefact is tagged according to the passed value or format, e.g. `my-custom-tag` or `semantic`. (The latter will use the project's version as the tag.)
 
-## Secrets backend
+### Secrets backend
 
 The core module implements a very basic secrets backend: `environmentVariable`. As the name suggests, it retrieves values from the process environment:
 
@@ -39,7 +40,7 @@ secrets:
     name: SOME_ENV_VAR
 ```
 
-# Definitions
+## 📚 Definitions
 
 The core module provides many Causa workspace function definitions. Some of those definitions are exposed as `cs` commands and provides the base functionalities for a Causa workspace. Some of the function definitions are implemented "generically" in this module, while others are meant to be implemented by other Causa modules, providing support of a specific project language or type.
 
@@ -51,7 +52,7 @@ This section provides pointers for Causa module developers. Workspace function d
 - [Infrastructure](./src/definitions/infrastructure.ts): Modules providing support for an Infrastructure as Code tool (e.g. Terraform, Pulumi) should implement the `InfrastructurePrepare` and `InfrastructureDeploy` functions.
 - [Project](./src/definitions/project.ts): Many of the definitions in this file should be implemented by modules providing support for a language and/or project type, e.g. `ProjectBuildArtefact`, `ProjectReadVersion`, `ProjectPushArtefact`, `ProjectGetArtefactDestination`.
 
-# Services
+## 🔨 Services
 
 This module implements some [services](./src/services/) used by itself, but which might also come handy in other modules, namely:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
-        "@causa/cli": ">= 0.3.3 < 1.0.0",
-        "@causa/workspace": ">= 0.7.0 < 1.0.0",
+        "@causa/cli": ">= 0.4.0 < 1.0.0",
+        "@causa/workspace": ">= 0.9.0 < 1.0.0",
         "axios": "^1.4.0",
         "class-validator": "^0.14.0",
         "pino": "^8.14.1"
       },
       "devDependencies": {
         "@tsconfig/node18": "^2.0.1",
-        "@types/jest": "^29.5.1",
-        "@types/node": "^18.16.14",
-        "eslint": "^8.41.0",
+        "@types/jest": "^29.5.2",
+        "@types/node": "^18.16.16",
+        "eslint": "^8.42.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.5.0",
-        "jest-extended": "^3.2.4",
+        "jest-extended": "^4.0.0",
         "rimraf": "^5.0.1",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.4"
+        "typescript": "^5.1.3"
       },
       "engines": {
         "node": ">=16"
@@ -59,30 +59,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.9.tgz",
-      "integrity": "sha512-FUGed8kfhyWvbYug/Un/VPJD41rDIgoVVcR+FuzhzOYyRz5uED+Gd3SLZml0Uw2l2aHFb7ZgdW5mGA3G2cCCnQ==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
+      "integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
-      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.1.tgz",
+      "integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-compilation-targets": "^7.21.5",
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.8",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/generator": "^7.22.0",
+        "@babel/helper-compilation-targets": "^7.22.1",
+        "@babel/helper-module-transforms": "^7.22.1",
+        "@babel/helpers": "^7.22.0",
+        "@babel/parser": "^7.22.0",
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -113,12 +113,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.9.tgz",
-      "integrity": "sha512-F3fZga2uv09wFdEjEQIJxXALXfz0+JaOb7SabvVMmjHxeVTuGW8wgE8Vp1Hd7O+zMTYtcfEISGRzPkeiaPPsvg==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.3.tgz",
+      "integrity": "sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.5",
+        "@babel/types": "^7.22.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -128,12 +128,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
-      "integrity": "sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
+      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.21.5",
+        "@babel/compat-data": "^7.22.0",
         "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-      "integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
+      "integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -202,19 +202,19 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz",
-      "integrity": "sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==",
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
+      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/helper-environment-visitor": "^7.22.1",
         "@babel/helper-module-imports": "^7.21.4",
         "@babel/helper-simple-access": "^7.21.5",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -281,14 +281,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
+      "integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.9.tgz",
-      "integrity": "sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
+      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -583,19 +583,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-      "integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.4.tgz",
+      "integrity": "sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/generator": "^7.22.3",
+        "@babel/helper-environment-visitor": "^7.22.1",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/parser": "^7.22.4",
+        "@babel/types": "^7.22.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.21.5",
@@ -633,11 +633,11 @@
       "dev": true
     },
     "node_modules/@causa/cli": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@causa/cli/-/cli-0.3.3.tgz",
-      "integrity": "sha512-PDJKyixGUUqCj44KzE6eu0XOzjAWm4qTBH3rqES7k8TQlZfRzrCYnehMOUgEpIS/72IzMbQypNAtt92hyqU9Gw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@causa/cli/-/cli-0.4.0.tgz",
+      "integrity": "sha512-QYawTxJ1kdmT+KVgyQ/VtTMD6hRSFJpTNag19ECveijrKLxPylU991EuCL0NEMhW6OqT0HTM8lFJc9jqtZcfww==",
       "dependencies": {
-        "@causa/workspace": ">= 0.7.0 < 1.0.0",
+        "@causa/workspace": ">= 0.9.0 < 1.0.0",
         "commander": "^10.0.1",
         "pino": "^8.14.1",
         "pino-pretty": "^10.0.0",
@@ -651,11 +651,11 @@
       }
     },
     "node_modules/@causa/workspace": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-0.7.0.tgz",
-      "integrity": "sha512-ofWr5jOb8utJTs8/pLYKLWyeAe9/VZx5aLVvLFeEH4YID5+ETJ7iTcXRL5jVBsGPZ30kYZuSo0x9gUGuLHuU2A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-0.9.0.tgz",
+      "integrity": "sha512-tP9ezX8dMvoCk6dqfAaSB2xqvKmyEnjh2Ta71qhmEXCtHIOM6E6GktsGdvqu7m7f4gqAAmTgNksCLp+4zzh0OA==",
       "dependencies": {
-        "@types/lodash": "^4.14.194",
+        "@types/lodash": "^4.14.195",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "globby": "^13.1.4",
@@ -739,18 +739,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -845,9 +845,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1458,9 +1458,9 @@
       "dev": true
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-      "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
+      "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -1490,12 +1490,12 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.18.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.5.tgz",
-      "integrity": "sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+      "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.3.0"
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
-      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "version": "29.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
+      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -1542,20 +1542,20 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.194",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
-      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g=="
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
     },
     "node_modules/@types/node": {
-      "version": "18.16.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
-      "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==",
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
       "dev": true
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -1885,9 +1885,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
+      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
       "dev": true,
       "funding": [
         {
@@ -1897,13 +1897,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001489",
+        "electron-to-chromium": "^1.4.411",
+        "node-releases": "^2.0.12",
+        "update-browserslist-db": "^1.0.11"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1981,9 +1985,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001489",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
-      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+      "version": "1.0.30001495",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
+      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
       "dev": true,
       "funding": [
         {
@@ -2276,9 +2280,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.404",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.404.tgz",
-      "integrity": "sha512-te57sWvQdpxmyd1GiswaodKdXdPgn9cN4ht8JlNa04QgtrfnUdWEo1261rY2vaC6TKaiHn0E7QerJWPKFCvMVw==",
+      "version": "1.4.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.425.tgz",
+      "integrity": "sha512-wv1NufHxu11zfDbY4fglYQApMswleE9FL/DSeyOyauVXDZ+Kco96JK/tPfBUaDqfRarYp2WH2hJ/5UnVywp9Jg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2338,16 +2342,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/js": "8.42.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -3540,9 +3544,9 @@
       }
     },
     "node_modules/jest-extended": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.4.tgz",
-      "integrity": "sha512-lSEYhSmvXZG/7YXI7KO3LpiUiQ90gi5giwCJNDMMsX5a+/NZhdbQF2G4ALOBN+KcXVT3H6FPVPohAuMXooaLTQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-4.0.0.tgz",
+      "integrity": "sha512-GMhMFdrwhYPB0y+cmI/5esz+F/Xc0OIzKbnr8SaiZ74YcWamxf7sVT78YlA15+JIQMTlpHBEgcxheyRBdHFqPA==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^29.0.0",
@@ -4035,9 +4039,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.30",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.30.tgz",
-      "integrity": "sha512-PLGc+xfrQrkya/YK2/5X+bPpxRmyJBHM+xxz9krUdSgk4Vs2ZwxX5/Ow0lv3r9PDlDtNWb4u+it8MY5rZ0IyGw=="
+      "version": "1.10.34",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.34.tgz",
+      "integrity": "sha512-p6g4NaQH4gK1gre32+kV14Mk6GPo2EDcPDvjbi+D2ycsPFsN4gVWNbs0itdHLZqByg6YEK8mE7OeP200I/ScTQ=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -4227,9 +4231,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -4436,9 +4440,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
-      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -4899,9 +4903,9 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
-      "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
+      "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5427,16 +5431,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -28,24 +28,24 @@
     "test:cov": "npm run test -- --coverage"
   },
   "dependencies": {
-    "@causa/cli": ">= 0.3.3 < 1.0.0",
-    "@causa/workspace": ">= 0.7.0 < 1.0.0",
+    "@causa/cli": ">= 0.4.0 < 1.0.0",
+    "@causa/workspace": ">= 0.9.0 < 1.0.0",
     "axios": "^1.4.0",
     "class-validator": "^0.14.0",
     "pino": "^8.14.1"
   },
   "devDependencies": {
     "@tsconfig/node18": "^2.0.1",
-    "@types/jest": "^29.5.1",
-    "@types/node": "^18.16.14",
-    "eslint": "^8.41.0",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^18.16.16",
+    "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
-    "jest-extended": "^3.2.4",
+    "jest-extended": "^4.0.0",
     "rimraf": "^5.0.1",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.3"
   }
 }

--- a/src/functions/environment-deploy.spec.ts
+++ b/src/functions/environment-deploy.spec.ts
@@ -80,10 +80,11 @@ describe('EnvironmentDeployForAll', () => {
 
     await context.call(EnvironmentDeploy, { deployment: '🚀' });
 
-    expect(processAndDeployMock).toHaveBeenCalledOnceWith(clonedContext, {
-      deployment: '🚀',
-    });
-    expect(context.clone).toHaveBeenCalledOnceWith({
+    expect(processAndDeployMock).toHaveBeenCalledExactlyOnceWith(
+      clonedContext,
+      { deployment: '🚀' },
+    );
+    expect(context.clone).toHaveBeenCalledExactlyOnceWith({
       workingDirectory: '/root/dir/somewhere/my/proj',
     });
   });
@@ -91,7 +92,7 @@ describe('EnvironmentDeployForAll', () => {
   it('should call process and deploy on the context if it is already set for the environment project', async () => {
     await context.call(EnvironmentDeploy, { deployment: '🚀' });
 
-    expect(processAndDeployMock).toHaveBeenCalledOnceWith(context, {
+    expect(processAndDeployMock).toHaveBeenCalledExactlyOnceWith(context, {
       deployment: '🚀',
     });
     expect(context.clone).not.toHaveBeenCalled();

--- a/src/functions/environment-prepare.spec.ts
+++ b/src/functions/environment-prepare.spec.ts
@@ -84,11 +84,11 @@ describe('EnvironmentPrepareForAll', () => {
     });
 
     expect(actualResult).toEqual({ isDeploymentNeeded: true, output: '🚀' });
-    expect(processAndPrepareMock).toHaveBeenCalledOnceWith(clonedContext, {
-      print: false,
-      output: '🚄',
-    });
-    expect(context.clone).toHaveBeenCalledOnceWith({
+    expect(processAndPrepareMock).toHaveBeenCalledExactlyOnceWith(
+      clonedContext,
+      { print: false, output: '🚄' },
+    );
+    expect(context.clone).toHaveBeenCalledExactlyOnceWith({
       workingDirectory: '/root/dir/somewhere/my/proj',
     });
   });
@@ -100,7 +100,7 @@ describe('EnvironmentPrepareForAll', () => {
     });
 
     expect(actualResult).toEqual({ isDeploymentNeeded: true, output: '🚀' });
-    expect(processAndPrepareMock).toHaveBeenCalledOnceWith(context, {
+    expect(processAndPrepareMock).toHaveBeenCalledExactlyOnceWith(context, {
       print: false,
       output: '🚄',
     });

--- a/src/functions/event-topic-generate-code-referenced-in-project.spec.ts
+++ b/src/functions/event-topic-generate-code-referenced-in-project.spec.ts
@@ -91,7 +91,7 @@ describe('EventTopicGenerateCodeReferencedInProjectForAll', () => {
     const expectedDefinitions = definitions.filter((d) =>
       actualTopicIds.includes(d.id),
     );
-    expect(generateCodeMock).toHaveBeenCalledOnceWith(context, {
+    expect(generateCodeMock).toHaveBeenCalledExactlyOnceWith(context, {
       definitions: expect.toContainAllValues(expectedDefinitions),
     });
   });

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -10,6 +10,7 @@ import { EventTopicListReferencedInProjectForServiceContainer } from './event-to
 import { EventTopicListForAll } from './event-topic-list.js';
 import { InfrastructureProcessAndDeployForAll } from './infrastructure-process-and-deploy.js';
 import { InfrastructureProcessAndPrepareForAll } from './infrastructure-process-and-prepare.js';
+import { ProjectInitForWorkspace } from './project-init-workspace.js';
 import { ProjectPublishArtefactForAll } from './project-publish-artefact.js';
 import { ProjectPushArtefactForServiceContainer } from './project-push-artefact-service-container.js';
 import { SecretFetchForEnvironmentVariable } from './secret-fetch-environment-variable.js';
@@ -27,6 +28,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
     EventTopicListForAll,
     InfrastructureProcessAndDeployForAll,
     InfrastructureProcessAndPrepareForAll,
+    ProjectInitForWorkspace,
     ProjectPublishArtefactForAll,
     ProjectPushArtefactForServiceContainer,
     SecretFetchForEnvironmentVariable,

--- a/src/functions/infrastructure-process-and-deploy.spec.ts
+++ b/src/functions/infrastructure-process-and-deploy.spec.ts
@@ -54,7 +54,7 @@ describe('InfrastructureProcessAndDeployForAll', () => {
       deployment: '🚀',
     });
 
-    expect(deployMock).toHaveBeenCalledOnceWith(context, {
+    expect(deployMock).toHaveBeenCalledExactlyOnceWith(context, {
       deployment: '🚀',
     });
   });
@@ -93,16 +93,16 @@ describe('InfrastructureProcessAndDeployForAll', () => {
       deployment: '🚀',
     });
 
-    expect(deployMock).toHaveBeenCalledOnceWith(clonedContext, {
+    expect(deployMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       deployment: '🚀',
     });
-    expect(context.clone).toHaveBeenCalledOnceWith({
+    expect(context.clone).toHaveBeenCalledExactlyOnceWith({
       processors: expectedProcessorInstructions,
     });
-    expect(firstProcessorMock).toHaveBeenCalledOnceWith(clonedContext, {
+    expect(firstProcessorMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       tearDown: true,
     });
-    expect(secondProcessorMock).toHaveBeenCalledOnceWith(clonedContext, {
+    expect(secondProcessorMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       arg1: 'val1',
       arg2: 'val2',
       tearDown: true,

--- a/src/functions/infrastructure-process-and-prepare.spec.ts
+++ b/src/functions/infrastructure-process-and-prepare.spec.ts
@@ -61,7 +61,7 @@ describe('InfrastructureProcessAndPrepareForAll', () => {
     });
 
     expect(actualResult).toEqual(expectedResult);
-    expect(prepareMock).toHaveBeenCalledOnceWith(context, {
+    expect(prepareMock).toHaveBeenCalledExactlyOnceWith(context, {
       print: true,
       output: '🚀',
     });
@@ -107,17 +107,17 @@ describe('InfrastructureProcessAndPrepareForAll', () => {
     });
 
     expect(actualResult).toEqual(expectedResult);
-    expect(prepareMock).toHaveBeenCalledOnceWith(clonedContext, {
+    expect(prepareMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       print: true,
       output: '🚀',
     });
-    expect(context.clone).toHaveBeenCalledOnceWith({
+    expect(context.clone).toHaveBeenCalledExactlyOnceWith({
       processors: expectedProcessorInstructions,
     });
-    expect(firstProcessorMock).toHaveBeenCalledOnceWith(clonedContext, {
+    expect(firstProcessorMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       tearDown: true,
     });
-    expect(secondProcessorMock).toHaveBeenCalledOnceWith(clonedContext, {
+    expect(secondProcessorMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       arg1: 'val1',
       arg2: 'val2',
       tearDown: true,

--- a/src/functions/project-init-workspace.spec.ts
+++ b/src/functions/project-init-workspace.spec.ts
@@ -1,0 +1,95 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { NoImplementationFoundError } from '@causa/workspace/function-registry';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import 'jest-extended';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { ProjectInit } from '../definitions/index.js';
+import type { ProjectInitForWorkspace as ProjectInitForWorkspaceType } from './project-init-workspace.js';
+
+const setUpCausaFolderMock = jest.fn(async () => {});
+jest.unstable_mockModule('@causa/workspace/initialization', () => ({
+  setUpCausaFolder: setUpCausaFolderMock,
+  CAUSA_FOLDER: '.causa',
+}));
+
+describe('ProjectInitWorkspace', () => {
+  let tmpDir: string;
+  let context: WorkspaceContext;
+  let ProjectInitForWorkspace: typeof ProjectInitForWorkspaceType;
+
+  beforeEach(async () => {
+    tmpDir = resolve(await mkdtemp(join(tmpdir(), 'causa-')));
+    ({ ProjectInitForWorkspace } = await import('./project-init-workspace.js'));
+    ({ context } = createContext({
+      rootPath: tmpDir,
+      configuration: {
+        workspace: { name: 'test' },
+        causa: { modules: { 'some-module': '2.0.0' } },
+      },
+      functions: [ProjectInitForWorkspace],
+    }));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should not support initialization of a specific project', async () => {
+    ({ context } = createContext({
+      configuration: {
+        workspace: { name: 'test' },
+        project: { name: 'my-proj', language: 'typescript', type: 'package' },
+      },
+      functions: [ProjectInitForWorkspace],
+    }));
+
+    expect(() => context.call(ProjectInit, {})).toThrow(
+      NoImplementationFoundError,
+    );
+  });
+
+  it('should be a no-op when no option is provided', async () => {
+    await context.call(ProjectInit, {});
+
+    expect(setUpCausaFolderMock).not.toHaveBeenCalled();
+  });
+
+  it('should reinstall module dependencies when the force option is provided', async () => {
+    const causaDir = join(tmpDir, '.causa');
+    const packageFile = join(causaDir, 'package.json');
+    await mkdir(causaDir, { recursive: true });
+    await writeFile(
+      packageFile,
+      JSON.stringify({ dependencies: { other: '1.0.0' } }),
+    );
+
+    await context.call(ProjectInit, { force: true });
+
+    expect(setUpCausaFolderMock).toHaveBeenCalledExactlyOnceWith(
+      context.rootPath,
+      { 'some-module': '2.0.0', other: '1.0.0' },
+      context.logger,
+    );
+  });
+
+  it('should default to initializing no modules', async () => {
+    ({ context } = createContext({
+      rootPath: tmpDir,
+      configuration: { workspace: { name: 'test' } },
+      functions: [ProjectInitForWorkspace],
+    }));
+    jest.spyOn(context.logger, 'warn');
+
+    await context.call(ProjectInit, { force: true });
+
+    expect(setUpCausaFolderMock).toHaveBeenCalledExactlyOnceWith(
+      context.rootPath,
+      {},
+      context.logger,
+    );
+    expect(context.logger.warn).toHaveBeenCalledOnce();
+  });
+});

--- a/src/functions/project-init-workspace.ts
+++ b/src/functions/project-init-workspace.ts
@@ -1,0 +1,65 @@
+import { WorkspaceContext } from '@causa/workspace';
+import {
+  CAUSA_FOLDER,
+  setUpCausaFolder,
+} from '@causa/workspace/initialization';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { ProjectInit } from '../definitions/index.js';
+
+/**
+ * Implements {@link ProjectInit} for the Causa workspace, outside of any actual project.
+ * This should be a no-op as being able to run this function means that the Causa folder is already initialized.
+ * However, if the `force` option is provided, the Causa folder will be reinitialized.
+ */
+export class ProjectInitForWorkspace extends ProjectInit {
+  async _call(context: WorkspaceContext): Promise<void> {
+    if (this.force) {
+      context.logger.info('🔥 Forcing reinstallation of Causa modules.');
+
+      const currentDependencies = await this.readCurrentDependencies(context);
+      // Merging the current dependencies allows keeping the ones that are not defined in the configuration, but might
+      // have been specified by a different process, e.g. the CLI
+      const modules = {
+        ...currentDependencies,
+        ...(context.get('causa.modules') ?? {}),
+      };
+
+      await setUpCausaFolder(context.rootPath, modules, context.logger);
+    }
+
+    context.logger.info('✅ Successfully initialized workspace dependencies.');
+  }
+
+  _supports(context: WorkspaceContext): boolean {
+    return (
+      context.get('project.name') === undefined &&
+      context.get('project.type') === undefined &&
+      context.get('project.language') === undefined
+    );
+  }
+
+  /**
+   * Parses the currently installed dependencies in the Causa folder from the `package.json` file.
+   *
+   * @param context The {@link WorkspaceContext}.
+   * @returns The currently installed dependencies in the Causa folder, or an empty object if the package file cannot be
+   *   read.
+   */
+  private async readCurrentDependencies(
+    context: WorkspaceContext,
+  ): Promise<Record<string, string>> {
+    try {
+      const causaDir = join(context.rootPath, CAUSA_FOLDER);
+      const packageFile = join(causaDir, 'package.json');
+      const packageJson = await readFile(packageFile);
+      return JSON.parse(packageJson.toString()).dependencies;
+    } catch (error) {
+      context.logger.warn(
+        `⚠️ Could not read the currently installed dependencies from the Causa folder: '${error}'.`,
+      );
+
+      return {};
+    }
+  }
+}

--- a/src/functions/project-publish-artefact.spec.ts
+++ b/src/functions/project-publish-artefact.spec.ts
@@ -58,7 +58,7 @@ describe('ProjectPublishArtefactForAll', () => {
 
     expect(actualDestination).toEqual('dst/abcd');
     expect(gitService.getCurrentShortSha).toHaveBeenCalledOnce();
-    expect(pushArtefactMock).toHaveBeenCalledOnceWith(context, {
+    expect(pushArtefactMock).toHaveBeenCalledExactlyOnceWith(context, {
       artefact: '🍱',
       destination: 'dst/abcd',
       overwrite: undefined,
@@ -74,7 +74,7 @@ describe('ProjectPublishArtefactForAll', () => {
 
     expect(actualDestination).toEqual('dst/abcd');
     expect(gitService.getCurrentShortSha).toHaveBeenCalledOnce();
-    expect(pushArtefactMock).toHaveBeenCalledOnceWith(context, {
+    expect(pushArtefactMock).toHaveBeenCalledExactlyOnceWith(context, {
       artefact: 'myArtefact',
       destination: 'dst/abcd',
       overwrite: undefined,
@@ -91,7 +91,7 @@ describe('ProjectPublishArtefactForAll', () => {
 
     expect(actualDestination).toEqual('dst/abcd');
     expect(gitService.getCurrentShortSha).toHaveBeenCalledOnce();
-    expect(pushArtefactMock).toHaveBeenCalledOnceWith(context, {
+    expect(pushArtefactMock).toHaveBeenCalledExactlyOnceWith(context, {
       artefact: '🍱',
       destination: 'dst/abcd',
       overwrite: true,
@@ -107,7 +107,7 @@ describe('ProjectPublishArtefactForAll', () => {
 
     expect(actualDestination).toEqual('dst/🔖');
     expect(gitService.getCurrentShortSha).not.toHaveBeenCalled();
-    expect(pushArtefactMock).toHaveBeenCalledOnceWith(context, {
+    expect(pushArtefactMock).toHaveBeenCalledExactlyOnceWith(context, {
       artefact: '🍱',
       destination: 'dst/🔖',
       overwrite: undefined,

--- a/src/functions/project-push-artefact-service-container.spec.ts
+++ b/src/functions/project-push-artefact-service-container.spec.ts
@@ -38,9 +38,12 @@ describe('ProjectPushArtefactForServiceContainer', () => {
     });
 
     expect(actualRemoteTag).toEqual(destination);
-    expect(dockerService.tag).toHaveBeenCalledOnceWith(artefact, destination);
-    expect(dockerService.push).toHaveBeenCalledOnceWith(destination);
-    expect(dockerService.exists).toHaveBeenCalledOnceWith(destination);
+    expect(dockerService.tag).toHaveBeenCalledExactlyOnceWith(
+      artefact,
+      destination,
+    );
+    expect(dockerService.push).toHaveBeenCalledExactlyOnceWith(destination);
+    expect(dockerService.exists).toHaveBeenCalledExactlyOnceWith(destination);
   });
 
   it('should not overwrite an existing remote image', async () => {
@@ -56,7 +59,7 @@ describe('ProjectPushArtefactForServiceContainer', () => {
     });
 
     await expect(actualPromise).rejects.toThrow(ArtefactAlreadyExistsError);
-    expect(dockerService.exists).toHaveBeenCalledOnceWith(destination);
+    expect(dockerService.exists).toHaveBeenCalledExactlyOnceWith(destination);
     expect(dockerService.tag).not.toHaveBeenCalled();
     expect(dockerService.push).not.toHaveBeenCalled();
   });
@@ -75,8 +78,11 @@ describe('ProjectPushArtefactForServiceContainer', () => {
     });
 
     expect(actualRemoteTag).toEqual(destination);
-    expect(dockerService.tag).toHaveBeenCalledOnceWith(artefact, destination);
-    expect(dockerService.push).toHaveBeenCalledOnceWith(destination);
+    expect(dockerService.tag).toHaveBeenCalledExactlyOnceWith(
+      artefact,
+      destination,
+    );
+    expect(dockerService.push).toHaveBeenCalledExactlyOnceWith(destination);
   });
 
   it('should not support other project types than service container', async () => {

--- a/src/services/docker-emulator.spec.ts
+++ b/src/services/docker-emulator.spec.ts
@@ -36,12 +36,12 @@ describe('DockerEmulatorService', () => {
         {},
       );
 
-      expect(dockerService.rm).toHaveBeenCalledOnceWith(
+      expect(dockerService.rm).toHaveBeenCalledExactlyOnceWith(
         ['my-container'],
         expect.anything(),
       );
       expect(dockerService.createNetworkIfNeeded).toHaveBeenCalledOnce();
-      expect(dockerService.run).toHaveBeenCalledOnceWith(
+      expect(dockerService.run).toHaveBeenCalledExactlyOnceWith(
         'my-image',
         expect.objectContaining({
           detach: true,
@@ -57,7 +57,7 @@ describe('DockerEmulatorService', () => {
     it('should remove the container', async () => {
       await service.stop('my-container');
 
-      expect(dockerService.rm).toHaveBeenCalledOnceWith(
+      expect(dockerService.rm).toHaveBeenCalledExactlyOnceWith(
         ['my-container'],
         expect.objectContaining({ force: true, volumes: true, logging: null }),
       );

--- a/src/services/docker.spec.ts
+++ b/src/services/docker.spec.ts
@@ -128,7 +128,7 @@ describe('DockerService', () => {
       const actualExists = await service.exists('myImage');
 
       expect(actualExists).toBeTrue();
-      expect(service.manifestInspect).toHaveBeenCalledOnceWith(
+      expect(service.manifestInspect).toHaveBeenCalledExactlyOnceWith(
         'myImage',
         expect.anything(),
       );
@@ -144,7 +144,7 @@ describe('DockerService', () => {
       const actualExists = await service.exists('myImage');
 
       expect(actualExists).toBeFalse();
-      expect(service.manifestInspect).toHaveBeenCalledOnceWith(
+      expect(service.manifestInspect).toHaveBeenCalledExactlyOnceWith(
         'myImage',
         expect.anything(),
       );
@@ -158,7 +158,7 @@ describe('DockerService', () => {
       const actualPromise = service.exists('myImage');
 
       await expect(actualPromise).rejects.toThrow('💥');
-      expect(service.manifestInspect).toHaveBeenCalledOnceWith(
+      expect(service.manifestInspect).toHaveBeenCalledExactlyOnceWith(
         'myImage',
         expect.anything(),
       );
@@ -289,7 +289,9 @@ describe('DockerService', () => {
       const actualNetworkName = await service.createNetworkIfNeeded();
 
       expect(actualNetworkName).toEqual('someCustomNetworkName');
-      expect(service.networkCreate).toHaveBeenCalledOnceWith(actualNetworkName);
+      expect(service.networkCreate).toHaveBeenCalledExactlyOnceWith(
+        actualNetworkName,
+      );
       expect(service.networkLs).not.toHaveBeenCalled();
     });
 
@@ -301,7 +303,9 @@ describe('DockerService', () => {
       const actualNetworkName = await service.createNetworkIfNeeded();
 
       expect(actualNetworkName).toEqual('someCustomNetworkName');
-      expect(service.networkCreate).toHaveBeenCalledOnceWith(actualNetworkName);
+      expect(service.networkCreate).toHaveBeenCalledExactlyOnceWith(
+        actualNetworkName,
+      );
       expect(service.networkLs).not.toHaveBeenCalled();
     });
 
@@ -318,8 +322,10 @@ describe('DockerService', () => {
       const actualNetworkName = await service.createNetworkIfNeeded();
 
       expect(actualNetworkName).toEqual('someCustomNetworkName');
-      expect(service.networkCreate).toHaveBeenCalledOnceWith(actualNetworkName);
-      expect(service.networkLs).toHaveBeenCalledOnceWith({
+      expect(service.networkCreate).toHaveBeenCalledExactlyOnceWith(
+        actualNetworkName,
+      );
+      expect(service.networkLs).toHaveBeenCalledExactlyOnceWith({
         filter: 'name=someCustomNetworkName',
         quiet: true,
       });
@@ -338,10 +344,10 @@ describe('DockerService', () => {
       const actualPromise = service.createNetworkIfNeeded();
 
       await expect(actualPromise).rejects.toThrow(ProcessServiceExitCodeError);
-      expect(service.networkCreate).toHaveBeenCalledOnceWith(
+      expect(service.networkCreate).toHaveBeenCalledExactlyOnceWith(
         'someCustomNetworkName',
       );
-      expect(service.networkLs).toHaveBeenCalledOnceWith({
+      expect(service.networkLs).toHaveBeenCalledExactlyOnceWith({
         filter: 'name=someCustomNetworkName',
         quiet: true,
       });

--- a/src/services/git.spec.ts
+++ b/src/services/git.spec.ts
@@ -34,7 +34,7 @@ describe('GitService', () => {
       const actualShortSha = await service.getCurrentShortSha();
 
       expect(actualShortSha).toEqual(expectedShortSha);
-      expect(service.git).toHaveBeenCalledOnceWith(
+      expect(service.git).toHaveBeenCalledExactlyOnceWith(
         'rev-parse',
         ['--short', 'HEAD'],
         expect.anything(),

--- a/src/services/process.spec.ts
+++ b/src/services/process.spec.ts
@@ -106,7 +106,7 @@ describe('ProcessService', () => {
       expect(logger.trace).toHaveBeenCalledTimes(2);
       expect(logger.trace).toHaveBeenCalledWith('🎉');
       expect(logger.trace).toHaveBeenCalledWith('✨');
-      expect(logger.warn).toHaveBeenCalledOnceWith('💣');
+      expect(logger.warn).toHaveBeenCalledExactlyOnceWith('💣');
     });
 
     it('should throw and return the correct exit code', async () => {


### PR DESCRIPTION
This PR defines new project-related function and commands, mostly to be implemented by language and project-specific modules.
The only exception is `ProjectInit` (the `cs init` command), which is supported at the workspace level, to (re)install Causa modules.

### Commits

- ✨ Define new project functions and commands
- ⬆️ Upgrade dependencies
- ✅ Adapt tests to jest-extended breaking change
- ✨ Implement ProjectInit for the workspace
- 📝 Update changelog
- 📝 Update documentation