### PR TITLE
✨ Improve configuration schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `EventsConfiguration`, and add new fields to `ServiceContainerConfiguration`.
+
 ## v0.8.0 (2023-07-24)
 
 Features:

--- a/src/configurations/events.ts
+++ b/src/configurations/events.ts
@@ -1,0 +1,39 @@
+/**
+ * Configuration for events.
+ */
+export type EventsConfiguration = {
+  /**
+   * Configuration for events and how they are exchanged between services.
+   */
+  readonly events?: {
+    /**
+     * The format to which events are serialized when exchanged through the message broker.
+     */
+    readonly format?: 'json';
+
+    /**
+     * The message broker used to exchange events between services.
+     */
+    readonly broker?: string;
+
+    /**
+     * Defines how topic definitions are found in the workspace.
+     */
+    readonly topics?: {
+      /**
+       * The format string using groups from the regular expression used to make the topic full names.
+       */
+      readonly format?: string;
+
+      /**
+       * A list of glob patterns to find topic schema definition files in the workspace.
+       */
+      readonly globs?: string[];
+
+      /**
+       * The regular expression used to extract groups from the topic schemas file paths.
+       */
+      readonly regularExpression?: string;
+    };
+  };
+};

--- a/src/configurations/index.ts
+++ b/src/configurations/index.ts
@@ -1,5 +1,6 @@
 export { CausaConfiguration } from './causa.js';
 export { DockerConfiguration } from './docker.js';
+export { EventsConfiguration } from './events.js';
 export { InfrastructureConfiguration } from './infrastructure-project.js';
 export { ServerlessFunctionsConfiguration } from './serverless-functions-project.js';
 export { ServiceContainerConfiguration } from './service-container-project.js';

--- a/src/configurations/service-container-project.ts
+++ b/src/configurations/service-container-project.ts
@@ -2,6 +2,13 @@
  * Configuration for service container projects.
  */
 export type ServiceContainerConfiguration = {
+  readonly project?: {
+    /**
+     * The deployed version of the service, which should correspond to a version tag in the container registry.
+     */
+    readonly activeVersion?: string;
+  };
+
   /**
    * Configuration for service container projects, i.e. services that are run as generic Docker containers.
    */
@@ -21,6 +28,41 @@ export type ServiceContainerConfiguration = {
      * Supports rendering.
      */
     readonly buildArgs?: Record<string, string>;
+
+    /**
+     * The endpoints exposed by the service.
+     */
+    readonly endpoints?: {
+      /**
+       * The HTTP endpoints exposed by the service.
+       */
+      readonly http?: string[];
+    };
+
+    /**
+     * The environment variables passed to the service.
+     */
+    readonly environmentVariables?: Record<string, string>;
+
+    /**
+     * The maximum CPU allowed to the container, as a "quantity" Kubernetes type.
+     */
+    readonly cpuLimit?: string;
+
+    /**
+     * The maximum memory allowed to the container, as a "quantity" Kubernetes type.
+     */
+    readonly memoryLimit?: string;
+
+    /**
+     * The minimum number of instances of the service that should be running.
+     */
+    readonly minInstances?: number;
+
+    /**
+     * The maximum number of instances of the service that should be running.
+     */
+    readonly maxInstances?: number;
 
     /**
      * A map of triggers that call the service's endpoints when they occur.

--- a/src/functions/event-topic-list.ts
+++ b/src/functions/event-topic-list.ts
@@ -1,4 +1,5 @@
 import { WorkspaceContext, listFilesAndFormat } from '@causa/workspace';
+import { EventsConfiguration } from '../configurations/index.js';
 import {
   DuplicateEventTopicError,
   EventTopicDefinition,
@@ -28,11 +29,12 @@ const DEFAULT_TOPIC_REGULAR_EXPRESSION =
  */
 export class EventTopicListForAll extends EventTopicList {
   async _call(context: WorkspaceContext): Promise<EventTopicDefinition[]> {
+    const eventsConf = context.asConfiguration<EventsConfiguration>();
     const format =
-      context.get('events.topics.format') ?? DEFAULT_TOPIC_ID_FORMAT;
-    const globs = context.get('events.topics.globs') ?? DEFAULT_TOPIC_GLOBS;
+      eventsConf.get('events.topics.format') ?? DEFAULT_TOPIC_ID_FORMAT;
+    const globs = eventsConf.get('events.topics.globs') ?? DEFAULT_TOPIC_GLOBS;
     const regExp =
-      context.get('events.topics.regularExpression') ??
+      eventsConf.get('events.topics.regularExpression') ??
       DEFAULT_TOPIC_REGULAR_EXPRESSION;
 
     const filesAndFormats = await listFilesAndFormat(


### PR DESCRIPTION
This PR introduces the missing `EventsConfiguration` type, and improves the `ServiceContainerConfiguration` type with fields that are used by the Cloud Run Causa Terraform module.

### Commits

- ✨ Define the EventsConfiguration
- ♻️ Use the typed EventsConfiguration in EventTopicListForAll
- ✨ Define additional configuration fields in the ServiceContainerConfiguration
- 📝 Update changelog