### PR TITLE
🐛 Ensure the project configurations directory is emptied before writing configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Features:
 
 - Define the `EventsConfiguration`, and add new fields to `ServiceContainerConfiguration`.
 
+Fixes:
+
+- Ensure the project configurations directory is emptied before writing configurations.
+
 ## v0.8.0 (2023-07-24)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,17 @@
         "@causa/workspace": ">= 0.12.0 < 1.0.0",
         "axios": "^1.4.0",
         "class-validator": "^0.14.0",
-        "pino": "^8.14.1"
+        "pino": "^8.14.2"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.0",
         "@types/jest": "^29.5.3",
-        "@types/node": "^18.17.0",
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@types/node": "^18.17.1",
+        "@typescript-eslint/eslint-plugin": "^6.2.0",
         "eslint": "^8.45.0",
-        "eslint-config-prettier": "^8.8.0",
+        "eslint-config-prettier": "^8.9.0",
         "eslint-plugin-prettier": "^5.0.0",
-        "jest": "^29.6.1",
+        "jest": "^29.6.2",
         "jest-extended": "^4.0.0",
         "rimraf": "^5.0.1",
         "ts-jest": "^29.1.1",
@@ -717,18 +717,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.0.tgz",
-      "integrity": "sha512-uiPeRISaglZnaZk8vwrjQZ1CxogZeY/4IYft6gBOTqu1WhVXWmCmZMWxUv2Q/pxSvPdp1JPaO62kLOcOkMqWrw==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -995,16 +995,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
-      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.2.tgz",
+      "integrity": "sha512-0N0yZof5hi44HAR2pPS+ikJ3nzKNoZdVu8FffRf3wy47I7Dm7etk/3KetMdRUqzVd16V4O2m2ISpNTbnIuqy1w==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1021,15 +1021,15 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
-      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.2.tgz",
+      "integrity": "sha512-Oj+5B+sDMiMWLhPFF+4/DvHOf+U10rgvCLGPHP8Xlsy/7QxS51aU/eBngudHlJXnaWD5EohAgJ4js+T6pa+zOg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.1",
-        "@jest/reporters": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/console": "^29.6.2",
+        "@jest/reporters": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -1038,20 +1038,20 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.6.1",
-        "jest-haste-map": "^29.6.1",
-        "jest-message-util": "^29.6.1",
+        "jest-config": "^29.6.2",
+        "jest-haste-map": "^29.6.2",
+        "jest-message-util": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-resolve-dependencies": "^29.6.1",
-        "jest-runner": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
-        "jest-watcher": "^29.6.1",
+        "jest-resolve": "^29.6.2",
+        "jest-resolve-dependencies": "^29.6.2",
+        "jest-runner": "^29.6.2",
+        "jest-runtime": "^29.6.2",
+        "jest-snapshot": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
+        "jest-watcher": "^29.6.2",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -1077,37 +1077,37 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
-      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.2.tgz",
+      "integrity": "sha512-AEcW43C7huGd/vogTddNNTDRpO6vQ2zaQNrttvWV18ArBx9Z56h7BIsXkNFJVOO4/kblWEQz30ckw0+L3izc+Q==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.6.1",
+        "@jest/fake-timers": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.1"
+        "jest-mock": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
-      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.2.tgz",
+      "integrity": "sha512-m6DrEJxVKjkELTVAztTLyS/7C92Y2b0VYqmDROYKLLALHn8T/04yPs70NADUYPrV3ruI+H3J0iUIuhkjp7vkfg==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.6.1",
-        "jest-snapshot": "^29.6.1"
+        "expect": "^29.6.2",
+        "jest-snapshot": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
-      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.2.tgz",
+      "integrity": "sha512-6zIhM8go3RV2IG4aIZaZbxwpOzz3ZiM23oxAlkquOIole+G6TrbeXnykxWYlqF7kz2HlBjdKtca20x9atkEQYg==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.4.3"
@@ -1117,47 +1117,47 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
-      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.2.tgz",
+      "integrity": "sha512-euZDmIlWjm1Z0lJ1D0f7a0/y5Kh/koLFMUBE5SUYWrmy8oNhJpbTBDAP6CxKnadcMLDoDf4waRYCe35cH6G6PA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.1",
-        "jest-mock": "^29.6.1",
-        "jest-util": "^29.6.1"
+        "jest-message-util": "^29.6.2",
+        "jest-mock": "^29.6.2",
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
-      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.2.tgz",
+      "integrity": "sha512-cjuJmNDjs6aMijCmSa1g2TNG4Lby/AeU7/02VtpW+SLcZXzOLK2GpN2nLqcFjmhy3B3AoPeQVx7BnyOf681bAw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/expect": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/expect": "^29.6.2",
         "@jest/types": "^29.6.1",
-        "jest-mock": "^29.6.1"
+        "jest-mock": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
-      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.2.tgz",
+      "integrity": "sha512-sWtijrvIav8LgfJZlrGCdN0nP2EWbakglJY49J1Y5QihcQLfy7ovyxxjJBRXMNltgt4uPtEcFmIMbVshEDfFWw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/console": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
@@ -1171,9 +1171,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1227,12 +1227,12 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
-      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.2.tgz",
+      "integrity": "sha512-3VKFXzcV42EYhMCsJQURptSqnyjqCGbtLuX5Xxb6Pm6gUf1wIRIl+mandIRGJyWKgNKYF9cnstti6Ls5ekduqw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.1",
+        "@jest/console": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
@@ -1242,14 +1242,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
-      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.2.tgz",
+      "integrity": "sha512-GVYi6PfPwVejO7slw6IDO0qKVum5jtrJ3KoLGbgBWyr2qr4GaxFV6su+ZAjdTX75Sr1DkMFRk09r2ZVa+wtCGw==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.1",
+        "@jest/test-result": "^29.6.2",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1266,9 +1266,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.2.tgz",
+      "integrity": "sha512-ZqCqEISr58Ce3U+buNFJYUktLJZOggfyvR+bZMaiV1e8B1SIvJbwZMrYz3gx/KAPn9EXmOmN+uB08yLCjWkQQg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -1279,9 +1279,9 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -1578,20 +1578,14 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.195",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
-      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+      "version": "4.14.196",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.196.tgz",
+      "integrity": "sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.17.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.0.tgz",
-      "integrity": "sha512-GXZxEtOxYGFchyUzxvKI14iff9KZ2DI+A6a37o6EQevtg6uO9t+aUZKcaC1Te5Ng1OnLM7K9NVVj+FbecD9cJg==",
-      "dev": true
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "version": "18.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.1.tgz",
+      "integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1627,16 +1621,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
-      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.0.tgz",
+      "integrity": "sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/type-utils": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/type-utils": "6.2.0",
+        "@typescript-eslint/utils": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1663,16 +1657,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
-      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.0.tgz",
+      "integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1692,13 +1686,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
-      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+      "integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0"
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1709,13 +1703,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
-      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.0.tgz",
+      "integrity": "sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/utils": "6.2.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1736,9 +1730,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+      "integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1749,13 +1743,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
-      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+      "integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1805,17 +1799,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+      "integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1830,12 +1824,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
-      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+      "integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/types": "6.2.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2011,12 +2005,12 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
-      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.2.tgz",
+      "integrity": "sha512-BYCzImLos6J3BH/+HvUCHG1dTf2MzmAB4jaVxHV+29RZLjR29XuYTmsf2sdDwkrb+FczkGo3kOhE7ga6sI0P4A==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.6.1",
+        "@jest/transform": "^29.6.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -2502,10 +2496,18 @@
       }
     },
     "node_modules/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.3.0.tgz",
+      "integrity": "sha512-7glNLfvdsMzZm3FpRY1CHuI2lbYDR+71YmrhmTZjYFD5pfT0ACgnGRdrrC9Mk2uICnzkcdelCx5at787UDGOvg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2557,9 +2559,9 @@
       }
     },
     "node_modules/default-browser/node_modules/execa": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-      "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -2743,9 +2745,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.468",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.468.tgz",
-      "integrity": "sha512-6M1qyhaJOt7rQtNti1lBA0GwclPH+oKCmsra/hkcWs5INLxfXXD/dtdnaKUYQu/pjOBP/8Osoe4mAcNvvzoFag==",
+      "version": "1.4.475",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.475.tgz",
+      "integrity": "sha512-mTye5u5P98kSJO2n7zYALhpJDmoSQejIGya0iR01GpoRady8eK3bw7YHHnjA1Rfi4ZSLdpuzlAC7Zw+1Zu7Z6A==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2859,9 +2861,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
+      "integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -2900,9 +2902,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
-      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2916,9 +2918,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3048,17 +3050,17 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
-      "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.2.tgz",
+      "integrity": "sha512-iAErsLxJ8C+S02QbLAwgSGSezLQK+XXRDt8IuFXFpwCNw2ECmzZSmjKcCaFVp5VRMk+WAvz6h6jokzEzBFZEuA==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.6.1",
+        "@jest/expect-utils": "^29.6.2",
         "@types/node": "*",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1"
+        "jest-matcher-utils": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3120,9 +3122,9 @@
       "dev": true
     },
     "node_modules/fast-redact": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
-      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
       "engines": {
         "node": ">=6"
       }
@@ -3788,17 +3790,17 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -3816,9 +3818,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -3829,9 +3831,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
-      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.2.tgz",
+      "integrity": "sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -3847,15 +3849,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
-      "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.2.tgz",
+      "integrity": "sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.1",
+        "@jest/core": "^29.6.2",
         "@jest/types": "^29.6.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.1"
+        "jest-cli": "^29.6.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3886,28 +3888,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
-      "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.2.tgz",
+      "integrity": "sha512-G9mN+KOYIUe2sB9kpJkO9Bk18J4dTDArNFPwoZ7WKHKel55eKIS/u2bLthxgojwlf9NLCVQfgzM/WsOVvoC6Fw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/expect": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/expect": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "dedent": "^0.7.0",
+        "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.6.1",
-        "jest-matcher-utils": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-each": "^29.6.2",
+        "jest-matcher-utils": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-runtime": "^29.6.2",
+        "jest-snapshot": "^29.6.2",
+        "jest-util": "^29.6.2",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -3926,21 +3928,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
-      "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.2.tgz",
+      "integrity": "sha512-TT6O247v6dCEX2UGHGyflMpxhnrL0DNqP2fRTKYm3nJJpCTfXX3GCMQPGFjXDoj0i5/Blp3jriKXFgdfmbYB6Q==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
+        "@jest/core": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
         "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
+        "jest-config": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -3960,31 +3962,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
-      "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.2.tgz",
+      "integrity": "sha512-VxwFOC8gkiJbuodG9CPtMRjBUNZEHxwfQXmIudSTzFWxaci3Qub1ddTRbFNQlD/zUeaifLndh/eDccFX4wCMQw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.1",
+        "@jest/test-sequencer": "^29.6.2",
         "@jest/types": "^29.6.1",
-        "babel-jest": "^29.6.1",
+        "babel-jest": "^29.6.2",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.1",
-        "jest-environment-node": "^29.6.1",
+        "jest-circus": "^29.6.2",
+        "jest-environment-node": "^29.6.2",
         "jest-get-type": "^29.4.3",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-runner": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
+        "jest-resolve": "^29.6.2",
+        "jest-runner": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -4014,15 +4016,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
-      "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.2.tgz",
+      "integrity": "sha512-t+ST7CB9GX5F2xKwhwCf0TAR17uNDiaPTZnVymP9lw0lssa9vG+AFyDZoeIHStU3WowFFwT+ky+er0WVl2yGhA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.4.3",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4041,33 +4043,33 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
-      "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.2.tgz",
+      "integrity": "sha512-MsrsqA0Ia99cIpABBc3izS1ZYoYfhIy0NNWqPSE0YXbQjwchyt6B1HD2khzyPe1WiJA7hbxXy77ZoUQxn8UlSw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
-        "jest-util": "^29.6.1",
-        "pretty-format": "^29.6.1"
+        "jest-util": "^29.6.2",
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
-      "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.2.tgz",
+      "integrity": "sha512-YGdFeZ3T9a+/612c5mTQIllvWkddPbYcN2v95ZH24oWMbGA4GGS2XdIF92QMhUhvrjjuQWYgUGW2zawOyH63MQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/fake-timers": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/fake-timers": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.1",
-        "jest-util": "^29.6.1"
+        "jest-mock": "^29.6.2",
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4104,9 +4106,9 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
-      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.2.tgz",
+      "integrity": "sha512-+51XleTDAAysvU8rT6AnS1ZJ+WHVNqhj1k6nTvN2PYP+HjU3kqlaKQ1Lnw3NYW3bm2r8vq82X0Z1nDDHZMzHVA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
@@ -4116,8 +4118,8 @@
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-util": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -4129,37 +4131,37 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
-      "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.2.tgz",
+      "integrity": "sha512-aNqYhfp5uYEO3tdWMb2bfWv6f0b4I0LOxVRpnRLAeque2uqOVVMLh6khnTcE2qJ5wAKop0HcreM1btoysD6bPQ==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
-      "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.2.tgz",
+      "integrity": "sha512-4LiAk3hSSobtomeIAzFTe+N8kL6z0JtF3n6I4fg29iIW7tt99R7ZcIFW34QkX+DuVrf+CUe6wuVOpm7ZKFJzZQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.1",
+        "jest-diff": "^29.6.2",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
-      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.2.tgz",
+      "integrity": "sha512-vnIGYEjoPSuRqV8W9t+Wow95SDp6KPX2Uf7EoeG9G99J2OVh7OSwpS4B6J0NfpEIpfkBNHlBZpA2rblEuEFhZQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -4168,7 +4170,7 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4186,14 +4188,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
-      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.2.tgz",
+      "integrity": "sha512-hoSv3lb3byzdKfwqCuT6uTscan471GUECqgNYykg6ob0yiAw3zYc7OrPnI9Qv8Wwoa4lC7AZ9hyS4AiIx5U2zg==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-util": "^29.6.1"
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4226,17 +4228,17 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
-      "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.2.tgz",
+      "integrity": "sha512-G/iQUvZWI5e3SMFssc4ug4dH0aZiZpsDq9o1PtXTV1210Ztyb2+w+ZgQkB3iOiC5SmAEzJBOHWz6Hvrd+QnNPw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -4246,13 +4248,13 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
-      "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.2.tgz",
+      "integrity": "sha512-LGqjDWxg2fuQQm7ypDxduLu/m4+4Lb4gczc13v51VMZbVP5tSBILqVx8qfWcsdP8f0G7aIqByIALDB0R93yL+w==",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "^29.4.3",
-        "jest-snapshot": "^29.6.1"
+        "jest-snapshot": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4268,30 +4270,30 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
-      "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.2.tgz",
+      "integrity": "sha512-wXOT/a0EspYgfMiYHxwGLPCZfC0c38MivAlb2lMEAlwHINKemrttu1uSbcGbfDV31sFaPWnWJPmb2qXM8pqZ4w==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.1",
-        "@jest/environment": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/console": "^29.6.2",
+        "@jest/environment": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.4.3",
-        "jest-environment-node": "^29.6.1",
-        "jest-haste-map": "^29.6.1",
-        "jest-leak-detector": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-resolve": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-watcher": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-environment-node": "^29.6.2",
+        "jest-haste-map": "^29.6.2",
+        "jest-leak-detector": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-resolve": "^29.6.2",
+        "jest-runtime": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-watcher": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -4300,17 +4302,17 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
-      "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.2.tgz",
+      "integrity": "sha512-2X9dqK768KufGJyIeLmIzToDmsN0m7Iek8QNxRSI/2+iPFYHF0jTwlO3ftn7gdKd98G/VQw9XJCk77rbTGZnJg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/fake-timers": "^29.6.1",
-        "@jest/globals": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/fake-timers": "^29.6.2",
+        "@jest/globals": "^29.6.2",
         "@jest/source-map": "^29.6.0",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -4318,13 +4320,13 @@
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-mock": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-mock": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-resolve": "^29.6.2",
+        "jest-snapshot": "^29.6.2",
+        "jest-util": "^29.6.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -4342,9 +4344,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
-      "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.2.tgz",
+      "integrity": "sha512-1OdjqvqmRdGNvWXr/YZHuyhh5DeaLp1p/F8Tht/MrMw4Kr1Uu/j4lRG+iKl1DAqUJDWxtQBMk41Lnf/JETYBRA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4352,21 +4354,20 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/expect-utils": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
-        "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.1",
+        "expect": "^29.6.2",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.1",
+        "jest-diff": "^29.6.2",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-matcher-utils": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -4374,9 +4375,9 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.2.tgz",
+      "integrity": "sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
@@ -4391,9 +4392,9 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
-      "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.2.tgz",
+      "integrity": "sha512-vGz0yMN5fUFRRbpJDPwxMpgSXW1LDKROHfBopAvDcmD6s+B/s8WJrwi+4bfH4SdInBA5C3P3BI19dBtKzx1Arg==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
@@ -4401,7 +4402,7 @@
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4420,18 +4421,18 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
-      "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.2.tgz",
+      "integrity": "sha512-GZitlqkMkhkefjfN/p3SJjrDaxPflqxEAv3/ik10OirZqJGYH5rPiIsgVcfof0Tdqg3shQGdEIxDBx+B4tuLzA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.1",
+        "@jest/test-result": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -4439,13 +4440,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.2.tgz",
+      "integrity": "sha512-l3ccBOabTdkng8I/ORCkADz4eSMKejTYv1vB/Z83UiubqhC1oQ5Li6dWCyqOIvSifGjUBxuvxvlm6KGK2DtuAQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -4567,9 +4568,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.37",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.37.tgz",
-      "integrity": "sha512-Z10PCaOCiAxbUxLyR31DNeeNugSVP6iv/m7UrSKS5JHziEMApJtgku4e9Q69pzzSC9LnQiM09sqsGf2ticZnMw=="
+      "version": "1.10.38",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.38.tgz",
+      "integrity": "sha512-4NjVXVUmpZ9Zsqq6FXa2+MKI+KAI3tOqA0pxXgXGluhpj4ge5didmbWJpMBqGB3AVGv1SnEtKdGTbxjSEG1kCQ=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -4619,27 +4620,18 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -5026,9 +5018,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.1.tgz",
-      "integrity": "sha512-8LYNv7BKWXSfS+k6oEc6occy5La+q2sPwU3q2ljTX5AZk7v+5kND2o5W794FyRaqha6DJajmkNRsWtPpFyMUdw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.2.tgz",
+      "integrity": "sha512-zKu9aWeSWTy1JgvxIpZveJKKsAr4+6uNMZ0Vf0KRwzl/UNZA3XjHiIl/0WwqLMkDwuHuDkT5xAgPA2jpKq4whA==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -5056,9 +5048,9 @@
       }
     },
     "node_modules/pino-pretty": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.1.0.tgz",
-      "integrity": "sha512-9gAgVHCVTEq0ThcjoXkOICYQgdqh1h90WSuVAnNeCrRrefJInUvMbpDfy6PlsI29Nbu9UW9CGkUHztrR1A9N+A==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+      "integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
@@ -5195,9 +5187,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
+      "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.0",
@@ -6006,9 +5998,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
     "@causa/workspace": ">= 0.12.0 < 1.0.0",
     "axios": "^1.4.0",
     "class-validator": "^0.14.0",
-    "pino": "^8.14.1"
+    "pino": "^8.14.2"
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.0",
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.17.0",
-    "@typescript-eslint/eslint-plugin": "^6.1.0",
+    "@types/node": "^18.17.1",
+    "@typescript-eslint/eslint-plugin": "^6.2.0",
     "eslint": "^8.45.0",
-    "eslint-config-prettier": "^8.8.0",
+    "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "jest": "^29.6.1",
+    "jest": "^29.6.2",
     "jest-extended": "^4.0.0",
     "rimraf": "^5.0.1",
     "ts-jest": "^29.1.1",

--- a/src/functions/project-write-configurations.spec.ts
+++ b/src/functions/project-write-configurations.spec.ts
@@ -46,7 +46,6 @@ describe('ProjectWriteConfigurations', () => {
       'project-configurations',
       `${project}.json`,
     );
-    console.log('Reading from file', configurationFile);
     const bufferConfiguration = await readFile(configurationFile);
     return JSON.parse(bufferConfiguration.toString());
   }

--- a/src/functions/project-write-configurations.ts
+++ b/src/functions/project-write-configurations.ts
@@ -47,48 +47,26 @@ export class ProjectWriteConfigurations
     );
   }
 
-  /**
-   * Removes the directory where project configurations are written.
-   * This is run when the `tearDown` option is set to `true`.
-   *
-   * @param context The {@link WorkspaceContext}.
-   * @returns An empty {@link ProcessorResult}.
-   */
-  private async tearDownConfigurationsDirectory(
-    context: WorkspaceContext,
-  ): Promise<ProcessorResult> {
+  async _call(context: WorkspaceContext): Promise<ProcessorResult> {
     const projectConfigurationsDirectory =
       this.getConfigurationsDirectory(context);
-
     const absoluteDirectory = resolve(
       context.rootPath,
       projectConfigurationsDirectory,
     );
-
-    context.logger.debug(
-      `🔧 Tearing down project configurations directory '${absoluteDirectory}'.`,
-    );
     await rm(absoluteDirectory, { recursive: true, force: true });
 
-    return { configuration: {} };
-  }
-
-  async _call(context: WorkspaceContext): Promise<ProcessorResult> {
     if (this.tearDown) {
-      return await this.tearDownConfigurationsDirectory(context);
+      context.logger.debug(
+        `🔧 Tore down project configurations directory '${absoluteDirectory}'.`,
+      );
+      return { configuration: {} };
     }
-
-    const projectConfigurationsDirectory =
-      this.getConfigurationsDirectory(context);
 
     context.logger.info('🔧 Rendering and writing project configurations.');
 
     const projectPaths = await context.listProjectPaths();
 
-    const absoluteDirectory = resolve(
-      context.rootPath,
-      projectConfigurationsDirectory,
-    );
     await mkdir(absoluteDirectory, { recursive: true });
 
     await Promise.all(


### PR DESCRIPTION
This PR fixes an unexpected behaviour where the temporary directory for project configurations would not be cleaned up. This could have been a problem when the temporary directory is not cleaned during tear down (if the previous execution finished unexpectedly).

### Commits

- ⬆️ Upgrade dependencies
- 🐛 Ensure the project configurations directory is emptied before writing configurations
- 📝 Update changelog