### PR TITLE
✨ Dependencies update command and destroy option for infrastructure prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `--destroy` option for the `infrastructure` and `environment prepare` commands.
+- Define the `ProjectDependenciesUpdate` and `ProjectDependenciesUpdateAndTest` functions, which define the `dependencies update` command.
+
 ## v0.9.0 (2023-07-28)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/jest": "^29.5.3",
         "@types/node": "^18.17.1",
         "@typescript-eslint/eslint-plugin": "^6.2.0",
-        "eslint": "^8.45.0",
+        "eslint": "^8.46.0",
         "eslint-config-prettier": "^8.9.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.6.2",
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
+      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2171,9 +2171,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "funding": [
         {
@@ -2190,9 +2190,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.11"
       },
       "bin": {
@@ -2496,9 +2496,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.3.0.tgz",
-      "integrity": "sha512-7glNLfvdsMzZm3FpRY1CHuI2lbYDR+71YmrhmTZjYFD5pfT0ACgnGRdrrC9Mk2uICnzkcdelCx5at787UDGOvg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.0.tgz",
+      "integrity": "sha512-3sSQTYoWKGcRHmHl6Y6opLpRJH55bxeGQ0Y1LCI5pZzUXvokVkj0FC4bi7uEwazxA9FQZ0Nv067Zt5kSUvXxEA==",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -2745,9 +2745,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.475",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.475.tgz",
-      "integrity": "sha512-mTye5u5P98kSJO2n7zYALhpJDmoSQejIGya0iR01GpoRady8eK3bw7YHHnjA1Rfi4ZSLdpuzlAC7Zw+1Zu7Z6A==",
+      "version": "1.4.477",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
+      "integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2807,27 +2807,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
+      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.1",
+        "@eslint/js": "^8.46.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.2",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3260,9 +3260,9 @@
       }
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^18.17.1",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
-    "eslint": "^8.45.0",
+    "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.6.2",

--- a/src/definitions/environment.ts
+++ b/src/definitions/environment.ts
@@ -7,7 +7,11 @@ import {
 import { WorkspaceFunction } from '@causa/workspace';
 import { AllowMissing } from '@causa/workspace/validation';
 import { IsBoolean, IsString } from 'class-validator';
-import { PrepareResult } from './infrastructure.js';
+import {
+  InfrastructureDeploy,
+  InfrastructurePrepare,
+  PrepareResult,
+} from './infrastructure.js';
 
 /**
  * The `environment` parent command, grouping all commands related to managing deployment environments.
@@ -30,13 +34,10 @@ After a deployment has been prepared, it can be deployed using the 'environment 
   summary: 'Prepares a future deployment of the environment.',
   outputFn: ({ output }) => console.log(output),
 })
-export abstract class EnvironmentPrepare extends WorkspaceFunction<
-  Promise<PrepareResult>
-> {
-  /**
-   * If `true` and changes have been prepared, they are printed to the standard output.
-   * This should probably not be used when calling this function programmatically.
-   */
+export abstract class EnvironmentPrepare
+  extends WorkspaceFunction<Promise<PrepareResult>>
+  implements InfrastructurePrepare
+{
   @IsBoolean()
   @AllowMissing()
   @CliOption({
@@ -46,9 +47,15 @@ export abstract class EnvironmentPrepare extends WorkspaceFunction<
   })
   readonly print?: boolean;
 
-  /**
-   * The location where the description of the future deployment (e.g. Terraform plan) should be written.
-   */
+  @IsBoolean()
+  @AllowMissing()
+  @CliOption({
+    flags: '--destroy',
+    description:
+      'If set, all infrastructure is destroyed instead of deploying changes.',
+  })
+  readonly destroy?: boolean;
+
   @IsString()
   @AllowMissing()
   @CliOption({
@@ -69,12 +76,10 @@ export abstract class EnvironmentPrepare extends WorkspaceFunction<
   description: `Deploys the infrastructure defined by the output of the 'environment prepare' command.`,
   summary: `Deploys an environment.`,
 })
-export abstract class EnvironmentDeploy extends WorkspaceFunction<
-  Promise<void>
-> {
-  /**
-   * The deployment changes to deploy (e.g. the path to a Terraform plan).
-   */
+export abstract class EnvironmentDeploy
+  extends WorkspaceFunction<Promise<void>>
+  implements InfrastructureDeploy
+{
   @IsString()
   @CliArgument({
     name: 'deployment',

--- a/src/definitions/infrastructure.ts
+++ b/src/definitions/infrastructure.ts
@@ -49,6 +49,13 @@ export abstract class InfrastructurePrepare extends WorkspaceFunction<
   readonly print?: boolean;
 
   /**
+   * If `true`, all infrastructure is destroyed instead of deploying changes.
+   */
+  @IsBoolean()
+  @AllowMissing()
+  readonly destroy?: boolean;
+
+  /**
    * The location where the description of the future deployment (e.g. Terraform plan) should be written.
    */
   @IsString()
@@ -96,13 +103,10 @@ After a deployment has been prepared, it can be deployed using the 'infrastructu
   summary: 'Prepares a future deployment of an infrastructure project.',
   outputFn: ({ output }) => console.log(output),
 })
-export abstract class InfrastructureProcessAndPrepare extends WorkspaceFunction<
-  Promise<PrepareResult>
-> {
-  /**
-   * If `true` and changes have been prepared, they are printed to the standard output.
-   * This should probably not be used when calling this function programmatically.
-   */
+export abstract class InfrastructureProcessAndPrepare
+  extends WorkspaceFunction<Promise<PrepareResult>>
+  implements InfrastructurePrepare
+{
   @IsBoolean()
   @AllowMissing()
   @CliOption({
@@ -112,9 +116,15 @@ export abstract class InfrastructureProcessAndPrepare extends WorkspaceFunction<
   })
   readonly print?: boolean;
 
-  /**
-   * The location where the description of the future deployment (e.g. Terraform plan) should be written.
-   */
+  @IsBoolean()
+  @AllowMissing()
+  @CliOption({
+    flags: '--destroy',
+    description:
+      'If set, all infrastructure is destroyed instead of deploying changes.',
+  })
+  readonly destroy?: boolean;
+
   @IsString()
   @AllowMissing()
   @CliOption({
@@ -136,12 +146,10 @@ export abstract class InfrastructureProcessAndPrepare extends WorkspaceFunction<
   description: `Deploys the infrastructure defined by the output of the 'infrastructure prepare' command.`,
   summary: `Deploys an infrastructure project.`,
 })
-export abstract class InfrastructureProcessAndDeploy extends WorkspaceFunction<
-  Promise<void>
-> {
-  /**
-   * The deployment changes to deploy (e.g. the path to a Terraform plan).
-   */
+export abstract class InfrastructureProcessAndDeploy
+  extends WorkspaceFunction<Promise<void>>
+  implements InfrastructureDeploy
+{
   @IsString()
   @CliArgument({
     name: 'deployment',

--- a/src/definitions/project.ts
+++ b/src/definitions/project.ts
@@ -239,6 +239,42 @@ export abstract class ProjectDependenciesCheck extends WorkspaceFunction<
 > {}
 
 /**
+ * Updates the project's dependencies.
+ * Depending on the provider, this might search for new versions online and install them, or simply update a lock file
+ * following a manual update of the dependencies.
+ */
+export abstract class ProjectDependenciesUpdate extends WorkspaceFunction<
+  Promise<void>
+> {}
+
+/**
+ * Updates the project's dependencies and runs tests to ensure there is no regression.
+ * Depending on the provider, this might search for new versions online and install them, or simply update a lock file
+ * following a manual update of the dependencies.
+ */
+@CliCommand({
+  parent: dependenciesCommandDefinition,
+  name: 'update',
+  description: `Updates the project's dependencies and runs tests to ensure there is no regression.
+Depending on the provider, this might search for new versions online and install them, or simply update a lock file following a manual update of the dependencies.`,
+  summary: `Updates the project's dependencies and run tests.`,
+})
+export abstract class ProjectDependenciesUpdateAndTest extends WorkspaceFunction<
+  Promise<void>
+> {
+  /**
+   * Skips running the tests before and after updating the dependencies.
+   */
+  @IsBoolean()
+  @AllowMissing()
+  @CliOption({
+    flags: '--skip-test',
+    description: `Skips running the tests before and after updating the dependencies.`,
+  })
+  readonly skipTest?: boolean;
+}
+
+/**
  * The `security` parent command, grouping all commands related to analyzing the security of a project.
  */
 export const securityCommandDefinition: ParentCliCommandDefinition = {

--- a/src/functions/environment-prepare.spec.ts
+++ b/src/functions/environment-prepare.spec.ts
@@ -96,12 +96,14 @@ describe('EnvironmentPrepareForAll', () => {
   it('should call process and deploy on the context if it is already set for the environment project', async () => {
     const actualResult = await context.call(EnvironmentPrepare, {
       print: false,
+      destroy: true,
       output: '🚄',
     });
 
     expect(actualResult).toEqual({ isDeploymentNeeded: true, output: '🚀' });
     expect(processAndPrepareMock).toHaveBeenCalledExactlyOnceWith(context, {
       print: false,
+      destroy: true,
       output: '🚄',
     });
     expect(context.clone).not.toHaveBeenCalled();

--- a/src/functions/environment-prepare.ts
+++ b/src/functions/environment-prepare.ts
@@ -18,6 +18,7 @@ export class EnvironmentPrepareForAll extends EnvironmentPrepare {
     return await context.call(InfrastructureProcessAndPrepare, {
       print: this.print,
       output: this.output,
+      destroy: this.destroy,
     });
   }
 

--- a/src/functions/infrastructure-process-and-prepare.spec.ts
+++ b/src/functions/infrastructure-process-and-prepare.spec.ts
@@ -103,12 +103,14 @@ describe('InfrastructureProcessAndPrepareForAll', () => {
 
     const actualResult = await context.call(InfrastructureProcessAndPrepare, {
       print: true,
+      destroy: true,
       output: '🚀',
     });
 
     expect(actualResult).toEqual(expectedResult);
     expect(prepareMock).toHaveBeenCalledExactlyOnceWith(clonedContext, {
       print: true,
+      destroy: true,
       output: '🚀',
     });
     expect(context.clone).toHaveBeenCalledExactlyOnceWith({

--- a/src/functions/infrastructure-process-and-prepare.ts
+++ b/src/functions/infrastructure-process-and-prepare.ts
@@ -16,6 +16,7 @@ export class InfrastructureProcessAndPrepareForAll extends InfrastructureProcess
     return await wrapInfrastructureOperation(context, (context) =>
       context.call(InfrastructurePrepare, {
         print: this.print,
+        destroy: this.destroy,
         output: this.output,
       }),
     );


### PR DESCRIPTION
This PR introduces the `ProjectDependenciesUpdate` and `ProjectDependenciesUpdateAndTest` functions, along with the `dependencies update` command.
It also defines the `--destroy` option for the `[infrastructure|environment] prepare` command.

### Commits

- ⬆️ Upgrade dependencies
- ✨ Define the --destroy option for infrastructure and environment prepare
- ✨ Define the ProjectDependenciesUpdate and ProjectDependenciesUpdateAndTest functions
- 📝 Update changelog