### PR TITLE
💥 `ProjectDependenciesUpdate` should return a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- `ProjectDependenciesUpdate` should now return a boolean indicating whether at least one dependency was updated.
+
+Features:
+
+- Do not run tests again if no dependency was updated.
+
 ## v0.11.0 (2023-07-31)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@tsconfig/node18": "^18.2.0",
         "@types/jest": "^29.5.3",
         "@types/node": "^18.17.1",
-        "@typescript-eslint/eslint-plugin": "^6.2.0",
+        "@typescript-eslint/eslint-plugin": "^6.2.1",
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^8.9.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -1601,9 +1601,9 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.7.17",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
-      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-NclP0IbzHj/4tJZKFqKh8E7kZdgss+MCUYV9G+TLltFfDA4lFgE4PKPpDIyS2FlcdANIfSx273emkupvChigbw=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -1621,16 +1621,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.0.tgz",
-      "integrity": "sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.1.tgz",
+      "integrity": "sha512-iZVM/ALid9kO0+I81pnp1xmYiFyqibAHzrqX4q5YvvVEyJqY+e6rfTXSCsc2jUxGNqJqTfFSSij/NFkZBiBzLw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.2.0",
-        "@typescript-eslint/type-utils": "6.2.0",
-        "@typescript-eslint/utils": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0",
+        "@typescript-eslint/scope-manager": "6.2.1",
+        "@typescript-eslint/type-utils": "6.2.1",
+        "@typescript-eslint/utils": "6.2.1",
+        "@typescript-eslint/visitor-keys": "6.2.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1657,16 +1657,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.0.tgz",
-      "integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.1.tgz",
+      "integrity": "sha512-Ld+uL1kYFU8e6btqBFpsHkwQ35rw30IWpdQxgOqOh4NfxSDH6uCkah1ks8R/RgQqI5hHPXMaLy9fbFseIe+dIg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.2.0",
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/typescript-estree": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0",
+        "@typescript-eslint/scope-manager": "6.2.1",
+        "@typescript-eslint/types": "6.2.1",
+        "@typescript-eslint/typescript-estree": "6.2.1",
+        "@typescript-eslint/visitor-keys": "6.2.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1686,13 +1686,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
-      "integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.1.tgz",
+      "integrity": "sha512-UCqBF9WFqv64xNsIEPfBtenbfodPXsJ3nPAr55mGPkQIkiQvgoWNo+astj9ZUfJfVKiYgAZDMnM6dIpsxUMp3Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0"
+        "@typescript-eslint/types": "6.2.1",
+        "@typescript-eslint/visitor-keys": "6.2.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1703,13 +1703,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.0.tgz",
-      "integrity": "sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.1.tgz",
+      "integrity": "sha512-fTfCgomBMIgu2Dh2Or3gMYgoNAnQm3RLtRp+jP7A8fY+LJ2+9PNpi5p6QB5C4RSP+U3cjI0vDlI3mspAkpPVbQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.2.0",
-        "@typescript-eslint/utils": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.1",
+        "@typescript-eslint/utils": "6.2.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1730,9 +1730,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
-      "integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.1.tgz",
+      "integrity": "sha512-528bGcoelrpw+sETlyM91k51Arl2ajbNT9L4JwoXE2dvRe1yd8Q64E4OL7vHYw31mlnVsf+BeeLyAZUEQtqahQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1743,13 +1743,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
-      "integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.1.tgz",
+      "integrity": "sha512-G+UJeQx9AKBHRQBpmvr8T/3K5bJa485eu+4tQBxFq0KoT22+jJyzo1B50JDT9QdC1DEmWQfdKsa8ybiNWYsi0Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0",
+        "@typescript-eslint/types": "6.2.1",
+        "@typescript-eslint/visitor-keys": "6.2.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1799,17 +1799,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
-      "integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.1.tgz",
+      "integrity": "sha512-eBIXQeupYmxVB6S7x+B9SdBeB6qIdXKjgQBge2J+Ouv8h9Cxm5dHf/gfAZA6dkMaag+03HdbVInuXMmqFB/lKQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.2.0",
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/scope-manager": "6.2.1",
+        "@typescript-eslint/types": "6.2.1",
+        "@typescript-eslint/typescript-estree": "6.2.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1824,12 +1824,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
-      "integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.1.tgz",
+      "integrity": "sha512-iTN6w3k2JEZ7cyVdZJTVJx2Lv7t6zFA8DCrJEHD2mwfc16AEvvBWVhbFh34XyG2NORCd0viIgQY1+u7kPI0WpA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/types": "6.2.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true,
       "funding": [
         {
@@ -2496,9 +2496,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.0.tgz",
-      "integrity": "sha512-3sSQTYoWKGcRHmHl6Y6opLpRJH55bxeGQ0Y1LCI5pZzUXvokVkj0FC4bi7uEwazxA9FQZ0Nv067Zt5kSUvXxEA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -2745,9 +2745,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.477",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
-      "integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw==",
+      "version": "1.4.479",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.479.tgz",
+      "integrity": "sha512-ABv1nHMIR8I5n3O3Een0gr6i0mfM+YcTZqjHy3pAYaOjgFG+BMquuKrSyfYf5CbEkLr9uM05RA3pOk4udNB/aQ==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tsconfig/node18": "^18.2.0",
     "@types/jest": "^29.5.3",
     "@types/node": "^18.17.1",
-    "@typescript-eslint/eslint-plugin": "^6.2.0",
+    "@typescript-eslint/eslint-plugin": "^6.2.1",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/src/definitions/project.ts
+++ b/src/definitions/project.ts
@@ -242,9 +242,10 @@ export abstract class ProjectDependenciesCheck extends WorkspaceFunction<
  * Updates the project's dependencies.
  * Depending on the provider, this might search for new versions online and install them, or simply update a lock file
  * following a manual update of the dependencies.
+ * Returns `true` if at least one dependency was updated, `false` otherwise.
  */
 export abstract class ProjectDependenciesUpdate extends WorkspaceFunction<
-  Promise<void>
+  Promise<boolean>
 > {}
 
 /**

--- a/src/functions/project-dependencies-update-and-test.spec.ts
+++ b/src/functions/project-dependencies-update-and-test.spec.ts
@@ -38,7 +38,7 @@ describe('ProjectDependenciesUpdateAndTestForAll', () => {
     dependenciesUpdateMock = registerMockFunction(
       functionRegistry,
       ProjectDependenciesUpdate,
-      async () => {},
+      async () => true,
     );
   });
 
@@ -99,6 +99,16 @@ describe('ProjectDependenciesUpdateAndTestForAll', () => {
     await context.call(ProjectDependenciesUpdateAndTest, {});
 
     expect(testMock).toHaveBeenCalledTimes(2);
+    expect(dependenciesUpdateMock).toHaveBeenCalledExactlyOnceWith(context, {});
+  });
+
+  it('should not run tests a second time if no dependency was updated', async () => {
+    registerTestMock();
+    dependenciesUpdateMock.mockImplementation(async () => false);
+
+    await context.call(ProjectDependenciesUpdateAndTest, {});
+
+    expect(testMock).toHaveBeenCalledExactlyOnceWith(context, {});
     expect(dependenciesUpdateMock).toHaveBeenCalledExactlyOnceWith(context, {});
   });
 });

--- a/src/functions/project-dependencies-update-and-test.ts
+++ b/src/functions/project-dependencies-update-and-test.ts
@@ -35,19 +35,28 @@ export class ProjectDependenciesUpdateAndTestForAll extends ProjectDependenciesU
       }
     }
 
-    await context.call(ProjectDependenciesUpdate, {});
+    const didUpdate = await context.call(ProjectDependenciesUpdate, {});
 
-    if (shouldRunTests) {
-      try {
-        context.logger.debug('Running tests after updating dependencies.');
-        await context.call(ProjectTest, {});
-      } catch (error) {
-        context.logger.error(
-          '❌ Tests failed after updating dependencies, you may want to rollback the update or fix the tests before continuing.',
-        );
+    if (!shouldRunTests) {
+      return;
+    }
 
-        throw error;
-      }
+    if (!didUpdate) {
+      context.logger.debug(
+        'Dependencies were not updated, skipping tests after updating dependencies.',
+      );
+      return;
+    }
+
+    try {
+      context.logger.debug('Running tests after updating dependencies.');
+      await context.call(ProjectTest, {});
+    } catch (error) {
+      context.logger.error(
+        '❌ Tests failed after updating dependencies, you may want to rollback the update or fix the tests before continuing.',
+      );
+
+      throw error;
     }
   }
 


### PR DESCRIPTION
This PR introduces a breaking change on `ProjectDependenciesUpdate` which should now return a boolean.
This allows the implementation of `ProjectDependenciesUpdateAndTest` not to run the tests twice if no dependency was updated.

### Commits

- ⬆️ Upgrade dependencies
- 💥 Change ProjectDependenciesUpdate definition to return a boolean
- ✨ Do not run tests again if no dependency was updated
- 📝 Update changelog