### PR TITLE
🔖 Prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0 (2023-08-01)
+
 Breaking changes:
 
 - `ProjectDependenciesUpdate` should now return a boolean indicating whether at least one dependency was updated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- `ProjectDependenciesUpdate` should now return a boolean indicating whether at least one dependency was updated.
- Make `GitService.diff` accept spawn options and return a process result.

Features:

- Do not run tests again if no dependency was updated.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.12.0