### PR TITLE
🐛 Fix `cs events backfill` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.causa/
 coverage/
 dist/
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Add missing decorators on `EventTopicBackfill.output` argument.
+
 ## v0.13.0 (2023-08-03)
 
 Features:

--- a/causa.yaml
+++ b/causa.yaml
@@ -1,0 +1,21 @@
+version: 1
+
+workspace:
+  name: causa
+
+project:
+  name: workspace-module-core
+  description: The Causa workspace module providing core function definitions and some implementations.
+  language: typescript
+  type: package
+
+causa:
+  modules:
+    '@causa/workspace-core': '>= 0.13.0'
+    '@causa/workspace-typescript': '>= 0.4.0'
+
+javascript:
+  dependencies:
+    update:
+      packageTargets:
+        '@types/node': minor

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@causa/workspace": ">= 0.12.0 < 1.0.0",
         "axios": "^1.4.0",
         "class-validator": "^0.14.0",
-        "pino": "^8.14.2"
+        "pino": "^8.15.0"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.0",
         "@types/jest": "^29.5.3",
-        "@types/node": "^18.17.1",
+        "@types/node": "^18.17.2",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^8.10.0",
@@ -1583,9 +1583,9 @@
       "integrity": "sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.1.tgz",
-      "integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==",
+      "version": "18.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.2.tgz",
+      "integrity": "sha512-wBo3KqP/PBqje5TI9UTiuL3yWfP6sdPtjtygSOqcYZWT232dfDeDOnkDps5wqZBP9NgGgYrNejinl0faAuE+HQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -2745,9 +2745,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.482",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.482.tgz",
-      "integrity": "sha512-h+UqpfmEr1Qkk0zp7ej/jid7CXoq4m4QzW6wNTb0ELJ/BZCpA4wgUylBIMGCe621tnr4l5VmoHjdoSx2lbnNJA==",
+      "version": "1.4.484",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.484.tgz",
+      "integrity": "sha512-nO3ZEomTK2PO/3TUXgEx0A97xZTpKVf4p427lABHuCpT1IQ2N+njVh29DkQkCk6Q4m2wjU+faK4xAcfFndwjvw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5018,9 +5018,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.2.tgz",
-      "integrity": "sha512-zKu9aWeSWTy1JgvxIpZveJKKsAr4+6uNMZ0Vf0KRwzl/UNZA3XjHiIl/0WwqLMkDwuHuDkT5xAgPA2jpKq4whA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+      "integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -6129,9 +6129,9 @@
       "dev": true
     },
     "node_modules/validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "@causa/workspace": ">= 0.12.0 < 1.0.0",
     "axios": "^1.4.0",
     "class-validator": "^0.14.0",
-    "pino": "^8.14.2"
+    "pino": "^8.15.0"
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.0",
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.17.1",
+    "@types/node": "^18.17.2",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.10.0",

--- a/src/definitions/event-topic.ts
+++ b/src/definitions/event-topic.ts
@@ -228,6 +228,8 @@ export abstract class EventTopicBackfill extends WorkspaceFunction<
     flags: '-o, --output <output>',
     description: `The path to the file that will be written with the temporary resources to delete. This is used by the 'cleanBackfill' command.`,
   })
+  @IsString()
+  @AllowMissing()
   readonly output?: string;
 }
 

--- a/src/functions/project-write-configurations.spec.ts
+++ b/src/functions/project-write-configurations.spec.ts
@@ -4,14 +4,15 @@ import { createContext } from '@causa/workspace/testing';
 import { existsSync } from 'fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import 'jest-extended';
-import { dirname, join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
 import { ProjectWriteConfigurations } from './project-write-configurations.js';
 
 describe('ProjectWriteConfigurations', () => {
   let context: WorkspaceContext;
 
   beforeEach(async () => {
-    const rootPath = resolve(await mkdtemp('causa-tests-'));
+    const rootPath = await mkdtemp(join(tmpdir(), 'causa-tests-'));
     ({ context } = createContext({
       rootPath,
       configuration: { workspace: { name: '🏷️' } },


### PR DESCRIPTION
This adds missing decorators on the `EventTopicBackfill` workspace function.
Also, this configures Causa to be used with the repository.

### Commits

- 🛠🔧 Configure Causa for the repository
- 🙈 Ignore Causa directory
- ⬆️ Upgrade dependencies
- ✅ Fix tests clashing with Causa configuration
- 🐛 Add missing decorators on EventTopicBackfill.output argument
- 📝 Update changelog