### PR TITLE
✨ Backfilling utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Define and implement backfilling utilities: `BackfillEvent`, `BackfillEventsSource`, `BackfillEventPublisher`, and `JsonFilesEventSource`.
+
 Fixes:
 
 - Add missing decorators on `EventTopicBackfill.output` argument.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ This module implements some [services](./src/services/) used by itself, but whic
 ### `ProjectWriteConfigurations`
 
 [ProjectWriteConfigurations](./src/functions/project-write-configurations.ts) is an infrastructure processor that writes the configuration of each and every project in the workspace to a single JSON file per project. This allows the configuration to be consumed by external systems that are not implemented in TypeScript and do not integrate directly with Causa. The output directory for the configuration files can be set in the `causa.projectConfigurationsDirectory` configuration, which defaults to `.causa/project-configurations`.
+
+## 📫 Backfilling utilities
+
+One of Causa's features is the ability to backfill events to be processed by services. Although there is always some stack-specific logic, some part of the backfilling flow can be implemented in a generic manner. The [backfill](./src/backfill/) folder contains utilities that may be reused by other Causa modules to provide backfilling functionalities.

--- a/src/backfill/event.ts
+++ b/src/backfill/event.ts
@@ -1,0 +1,19 @@
+/**
+ * A single event that should be published.
+ */
+export type BackfillEvent = {
+  /**
+   * The data to publish.
+   */
+  data: Buffer;
+
+  /**
+   * Optional attributes for the message.
+   */
+  attributes?: Record<string, string>;
+
+  /**
+   * Optional ordering key for the message.
+   */
+  key?: string;
+};

--- a/src/backfill/index.ts
+++ b/src/backfill/index.ts
@@ -1,3 +1,4 @@
 export * from './event.js';
 export { JsonFilesEventSource } from './json-files-source.js';
+export { BackfillEventPublisher } from './publisher.js';
 export * from './source.js';

--- a/src/backfill/index.ts
+++ b/src/backfill/index.ts
@@ -1,0 +1,2 @@
+export * from './event.js';
+export * from './source.js';

--- a/src/backfill/index.ts
+++ b/src/backfill/index.ts
@@ -1,2 +1,3 @@
 export * from './event.js';
+export { JsonFilesEventSource } from './json-files-source.js';
 export * from './source.js';

--- a/src/backfill/json-files-source.spec.ts
+++ b/src/backfill/json-files-source.spec.ts
@@ -1,0 +1,152 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import 'jest-extended';
+import { resolve } from 'path';
+import { BackfillEvent } from './event.js';
+import { JsonFilesEventSource } from './json-files-source.js';
+
+describe('JsonFilesEventSource', () => {
+  let tmpDir: string;
+  let context: WorkspaceContext;
+
+  beforeEach(async () => {
+    tmpDir = resolve(await mkdtemp('causa-test-'));
+    ({ context } = createContext({
+      rootPath: tmpDir,
+      configuration: { workspace: { name: 'my-workspace' } },
+    }));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('fromSourceAndFilter', () => {
+    it('should return null if the source is not a JSON files source', async () => {
+      const actualSource = await JsonFilesEventSource.fromSourceAndFilter(
+        context,
+        'bq://my-project/my-dataset/my-table',
+        undefined,
+      );
+
+      expect(actualSource).toBeNull();
+    });
+
+    it('should throw if a filter is provided', async () => {
+      const actualPromise = JsonFilesEventSource.fromSourceAndFilter(
+        context,
+        'json://some-glob',
+        'attribute = "value"',
+      );
+
+      expect(actualPromise).rejects.toThrow(
+        'Filtering JSON events from files is not supported.',
+      );
+    });
+
+    it('should initialize the source', async () => {
+      const file1 = resolve(tmpDir, 'file1.json');
+      const file2 = resolve(tmpDir, 'file2.json');
+      await writeFile(file1, '1️⃣');
+      await writeFile(file2, '2️⃣');
+      await writeFile(resolve(tmpDir, 'file3.txt'), '❌');
+
+      const actualSource = await JsonFilesEventSource.fromSourceAndFilter(
+        context,
+        `json://${tmpDir}/*.json`,
+        undefined,
+      );
+
+      expect(actualSource).toBeInstanceOf(JsonFilesEventSource);
+      expect(actualSource?.files).toEqual([file1, file2]);
+    });
+  });
+
+  describe('getBatch', () => {
+    let source: JsonFilesEventSource | null;
+
+    afterEach(async () => {
+      await source?.dispose();
+    });
+
+    async function createJsonFile(
+      name: string,
+      numLines: number,
+    ): Promise<string> {
+      let content = '';
+      for (let i = 0; i < numLines; i++) {
+        content +=
+          JSON.stringify({
+            data: `${i}`,
+            attributes: { someAttribute: `${name} ${i}` },
+          }) + '\n';
+      }
+      const path = resolve(tmpDir, name);
+      await writeFile(path, content);
+      return path;
+    }
+
+    it('should read files in batches', async () => {
+      await createJsonFile('file1.json', 20000);
+      await createJsonFile('file2.json', 17000);
+      source = await JsonFilesEventSource.fromSourceAndFilter(
+        context,
+        `json://${tmpDir}/*.json`,
+        undefined,
+      );
+
+      let batch: BackfillEvent[] | null | undefined;
+      const batches: BackfillEvent[][] = [];
+      while ((batch = await source?.getBatch())) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(4);
+      const actualNumEvents = batches.reduce(
+        (sum, batch) => sum + batch.length,
+        0,
+      );
+      expect(actualNumEvents).toEqual(37000);
+      expect(
+        new Set(
+          batches.flatMap((b) => b.map((e) => e.attributes?.someAttribute)),
+        ).size,
+      ).toEqual(37000);
+    });
+
+    it('should ignore and log invalid events', async () => {
+      await createJsonFile('file1.json', 1);
+      await writeFile(resolve(tmpDir, 'file2.json'), 'nope\n');
+      await createJsonFile('file3.json', 1);
+      source = await JsonFilesEventSource.fromSourceAndFilter(
+        context,
+        `json://${tmpDir}/*.json`,
+        undefined,
+      );
+      jest.spyOn(context.logger, 'error');
+
+      let batch: BackfillEvent[] | null | undefined;
+      const batches: BackfillEvent[][] = [];
+      while ((batch = await source?.getBatch())) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(3);
+      const actualNumEvents = batches.reduce(
+        (sum, batch) => sum + batch.length,
+        0,
+      );
+      expect(actualNumEvents).toEqual(2);
+      expect(
+        new Set(
+          batches.flatMap((b) => b.map((e) => e.attributes?.someAttribute)),
+        ).size,
+      ).toEqual(2);
+      expect(context.logger.error).toHaveBeenCalledExactlyOnceWith(
+        expect.stringMatching(`Failed to parse event 'nope':`),
+      );
+    });
+  });
+});

--- a/src/backfill/json-files-source.ts
+++ b/src/backfill/json-files-source.ts
@@ -1,0 +1,162 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { once } from 'events';
+import { FileHandle, open } from 'fs/promises';
+import { globby } from 'globby';
+import { Interface } from 'readline';
+import { BackfillEvent } from './event.js';
+import { BackfillEventsSource } from './source.js';
+
+/**
+ * The approximate size of a batch of events fetched from the source.
+ * The actual size may vary.
+ */
+const EVENT_BATCH_SIZE = 10000;
+
+/**
+ * A {@link BackfillEventsSource} that reads newline-delimited JSON events from files.
+ */
+export class JsonFilesEventSource implements BackfillEventsSource {
+  /**
+   * The index of the next file to read.
+   */
+  private nextFileIndex = 0;
+
+  /**
+   * The current batch of events being buffered.
+   */
+  private currentBatch: BackfillEvent[] = [];
+
+  /**
+   * The handle of the current file being read.
+   */
+  private currentFileHandle: FileHandle | null = null;
+
+  /**
+   * The line interface of the current file being read.
+   */
+  private currentLines: Interface | null = null;
+
+  /**
+   * A promise that resolves when the current file is closed.
+   */
+  private closePromise: Promise<void> | null = null;
+
+  private constructor(
+    readonly context: WorkspaceContext,
+    readonly files: string[],
+  ) {}
+
+  /**
+   * Parses a single line as a JSON object and returns the corresponding {@link BackfillEvent}.
+   *
+   * @param line The line to parse.
+   * @returns The parsed event, or `null` if the line could not be parsed.
+   */
+  private parseEvent(line: string): BackfillEvent | null {
+    try {
+      const event = JSON.parse(line);
+      const data = Buffer.from(event.data);
+      return { data, attributes: event.attributes, key: event.key };
+    } catch (error) {
+      this.context.logger.error(
+        `❌ Failed to parse event '${line}': '${error}'.`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Sets up the next file to read by creating a handle and a line interface for it.
+   *
+   * @returns The `readline` {@link Interface} for the next file, or `null` if there are no more files.
+   */
+  private async setUpNextFile(): Promise<Interface | null> {
+    if (this.nextFileIndex >= this.files.length) {
+      return null;
+    }
+
+    const handle = await open(this.files[this.nextFileIndex]);
+    const lines = handle.readLines();
+    lines.pause();
+    lines.on('line', (line) => {
+      const event = this.parseEvent(line);
+      if (!event) {
+        return;
+      }
+
+      this.currentBatch.push(event);
+
+      if (this.currentBatch.length === EVENT_BATCH_SIZE) {
+        lines.pause();
+      }
+    });
+
+    this.currentFileHandle = handle;
+    this.currentLines = lines;
+    this.closePromise = once(lines, 'close').then(async () => {
+      this.currentFileHandle = null;
+      this.currentLines = null;
+      await handle.close();
+    });
+
+    this.nextFileIndex++;
+
+    return lines;
+  }
+
+  async getBatch(): Promise<BackfillEvent[] | null> {
+    const currentLines = this.currentLines ?? (await this.setUpNextFile());
+    if (!currentLines) {
+      return null;
+    }
+
+    const pausePromise = once(currentLines, 'pause');
+    currentLines.resume();
+
+    await Promise.race([pausePromise, this.closePromise]);
+
+    const batch = this.currentBatch;
+    this.currentBatch = [];
+    return batch;
+  }
+
+  async dispose(): Promise<void> {
+    await this.currentFileHandle?.close();
+    this.currentBatch = [];
+    this.closePromise = null;
+    this.currentLines = null;
+    this.currentFileHandle = null;
+    this.nextFileIndex = this.files.length;
+  }
+
+  /**
+   * Creates a {@link JsonFilesEventSource} from a source string.
+   * The source string should be of the form `json://<glob>`, where `<glob>` is a glob pattern matching the files to
+   * read.
+   * The `filter` argument is not supported and should be `undefined`.
+   *
+   * @param context The {@link WorkspaceContext}.
+   * @param source A string describing the source of the events.
+   * @param filter An optional filter to select events.
+   *   This is not supported and should be `undefined`.
+   * @returns A {@link JsonFilesEventSource} if the source is a valid JSON files source, or `null` otherwise.
+   */
+  static async fromSourceAndFilter(
+    context: WorkspaceContext,
+    source: string,
+    filter?: string,
+  ): Promise<JsonFilesEventSource | null> {
+    const match = source.match(/^json:\/\/(?<glob>.+)$/);
+    if (!match?.groups?.glob) {
+      return null;
+    }
+
+    if (filter) {
+      throw new Error('Filtering JSON events from files is not supported.');
+    }
+
+    const files = await globby(match.groups.glob, { onlyFiles: true });
+
+    return new JsonFilesEventSource(context, files.sort());
+  }
+}

--- a/src/backfill/publisher.spec.ts
+++ b/src/backfill/publisher.spec.ts
@@ -1,0 +1,103 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import { setTimeout } from 'timers/promises';
+import { BackfillEvent } from './event.js';
+import { BackfillEventPublisher } from './publisher.js';
+import { BackfillEventsSource } from './source.js';
+
+class MyPublisher extends BackfillEventPublisher {
+  publishEvent(): Promise<void> | null {
+    return null;
+  }
+
+  async flush(): Promise<void> {}
+}
+
+describe('BackfillEventPublisher', () => {
+  let context: WorkspaceContext;
+  let publisher: BackfillEventPublisher;
+  let publishEventMock: jest.SpiedFunction<
+    (event: BackfillEvent) => Promise<void> | null
+  >;
+  let flushMock: jest.SpiedFunction<() => Promise<void>>;
+
+  beforeEach(() => {
+    ({ context } = createContext({
+      configuration: {
+        workspace: { name: 'my-workspace' },
+        events: { broker: 'google.pubSub' },
+        google: { project: 'my-project' },
+      },
+    }));
+    publisher = new MyPublisher(context);
+    publishEventMock = jest.spyOn(publisher as any, 'publishEvent');
+    flushMock = jest.spyOn(publisher as any, 'flush');
+  });
+
+  function makeSource(
+    numBatches: number,
+    numEventsInBatch: number,
+  ): BackfillEventsSource {
+    let batchIndex = 0;
+    return {
+      getBatch: async () => {
+        if (batchIndex >= numBatches) {
+          return null;
+        }
+        batchIndex++;
+        return Array.from({ length: numEventsInBatch }, (_, i) => ({
+          data: Buffer.from(`${batchIndex}-${i}`),
+          attributes: { batch: `${batchIndex}`, index: `${i}` },
+        }));
+      },
+      dispose: jest.fn(() => Promise.resolve()),
+    };
+  }
+
+  it('should publish the events', async () => {
+    const source = makeSource(2, 3);
+
+    await publisher.publishFromSource(source);
+
+    expect(publisher['publishEvent']).toHaveBeenCalledTimes(6);
+    const actualMessages = publishEventMock.mock.calls.map(([msg]) => ({
+      ...msg,
+      data: msg.data.toString(),
+    }));
+    expect(actualMessages).toEqual([
+      { data: '1-0', attributes: { batch: '1', index: '0' } },
+      { data: '1-1', attributes: { batch: '1', index: '1' } },
+      { data: '1-2', attributes: { batch: '1', index: '2' } },
+      { data: '2-0', attributes: { batch: '2', index: '0' } },
+      { data: '2-1', attributes: { batch: '2', index: '1' } },
+      { data: '2-2', attributes: { batch: '2', index: '2' } },
+    ]);
+    expect(flushMock).toHaveBeenCalledOnce();
+    expect(source.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('should wait for the publisher to catch up', async () => {
+    const source = makeSource(2, 3);
+    let waitPromiseResolve!: () => void;
+    const waitPromise = new Promise<void>(
+      (resolve) => (waitPromiseResolve = resolve),
+    );
+    publishEventMock.mockImplementationOnce(() => waitPromise);
+
+    const publishPromise = publisher.publishFromSource(source);
+    await setTimeout(50);
+
+    expect(publishEventMock).toHaveBeenCalledExactlyOnceWith({
+      data: expect.toSatisfy((d) => d.toString() === '1-0'),
+      attributes: { batch: '1', index: '0' },
+    });
+    expect(flushMock).not.toHaveBeenCalled();
+    waitPromiseResolve();
+
+    await publishPromise;
+    expect(publishEventMock).toHaveBeenCalledTimes(6);
+    expect(flushMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/backfill/publisher.ts
+++ b/src/backfill/publisher.ts
@@ -1,0 +1,64 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { BackfillEvent } from './event.js';
+import { BackfillEventsSource } from './source.js';
+
+/**
+ * A publisher that publishes events to backfill by getting batches of events from a source.
+ */
+export abstract class BackfillEventPublisher {
+  constructor(protected readonly context: WorkspaceContext) {}
+
+  /**
+   * Publishes an event to the configured topic.
+   *
+   * @param event The event to publish.
+   * @returns A promise that resolves when the publisher has caught up with publishing, or `null` if other events can be
+   *   published immediately.
+   */
+  protected abstract publishEvent(event: BackfillEvent): Promise<void> | null;
+
+  /**
+   * Waits for all events to be published.
+   */
+  protected abstract flush(): Promise<void>;
+
+  /**
+   * Publishes all events from the given source.
+   *
+   * @param source The source of events to publish.
+   */
+  async publishFromSource(source: BackfillEventsSource): Promise<void> {
+    this.context.logger.info('📫 Publishing events.');
+
+    let numEvents = 0;
+    try {
+      while (true) {
+        this.context.logger.debug('Requesting a batch of events.');
+        const events = await source.getBatch();
+        if (!events) {
+          this.context.logger.debug('No more events to publish.');
+          break;
+        }
+        this.context.logger.debug(`Fetched ${events.length} events.`);
+
+        for (const event of events) {
+          numEvents += 1;
+
+          const wait = this.publishEvent(event);
+          if (wait) {
+            this.context.logger.debug(
+              'Waiting for the publisher to catch up before resuming publishing.',
+            );
+            await wait;
+          }
+        }
+      }
+    } finally {
+      await source.dispose();
+    }
+
+    await this.flush();
+
+    this.context.logger.info(`📫 Finished publishing ${numEvents} events.`);
+  }
+}

--- a/src/backfill/source.ts
+++ b/src/backfill/source.ts
@@ -1,0 +1,20 @@
+import { BackfillEvent } from './event.js';
+
+/**
+ * A source that retrieves events to publish in batch.
+ */
+export interface BackfillEventsSource {
+  /**
+   * Retrieves a batch of events to publish.
+   * `null` indicates that there are no more events to publish, however events should still be fetched if an empty array
+   * is returned.
+   *
+   * @returns A batch of events to publish, or `null` if there are no more events to publish.
+   */
+  getBatch(): Promise<BackfillEvent[] | null>;
+
+  /**
+   * Ensures that the source is properly terminated.
+   */
+  dispose(): Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { ModuleRegistrationFunction } from '@causa/workspace';
 import { registerFunctions } from './functions/index.js';
 
+export * from './backfill/index.js';
 export * from './configurations/index.js';
 export * from './definitions/index.js';
 export * from './services/index.js';


### PR DESCRIPTION
This PR implements generic backfilling utilities, meant to be reused by other Causa modules that will then implement the tech stack-specific backfilling logic.

### Commits

- ✨ Define BackfillEvent and BackfillEventsSource
- ✨ Implement the JsonFilesEventSource
- ✨ Implement the BackfillEventPublisher
- 📝 Update changelog
- 📝 Document the backfilling utilities