### PR TITLE
✨ Support for env file when running a Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
 
 - Define the `OpenApiGenerateSpecification` workspace function (`cs openapi genSpec`) and provide its workspace-level implementation, which merges all OpenAPI specifications in a single file.
+- Support the `envFile` options for `DockerService.run`.
 
 ## v0.14.1 (2023-08-04)
 

--- a/src/services/docker.spec.ts
+++ b/src/services/docker.spec.ts
@@ -218,6 +218,7 @@ describe('DockerService', () => {
           },
         ],
         env: { FIRST_ENV: '😍', SECOND_ENV: undefined },
+        envFile: '/some/file',
         rm: true,
         network: 'someNetwork',
       });
@@ -240,6 +241,7 @@ describe('DockerService', () => {
       expect(actualArgs).toContain('--env SECOND_ENV');
       expect(actualArgs).toContain('--rm');
       expect(actualArgs).toContain('--network someNetwork');
+      expect(actualArgs).toContain('--env-file /some/file');
     });
   });
 

--- a/src/services/docker.ts
+++ b/src/services/docker.ts
@@ -305,6 +305,11 @@ export class DockerService {
       env?: Record<string, string | undefined>;
 
       /**
+       * The path to a file containing environment variables to pass to the container.
+       */
+      envFile?: string;
+
+      /**
        * Automatically removes the container when it exits.
        */
       rm?: boolean;
@@ -321,6 +326,7 @@ export class DockerService {
       workdir,
       mounts,
       env,
+      envFile,
       name,
       detach,
       publish,
@@ -351,6 +357,10 @@ export class DockerService {
       }
       args.splice(0, 0, '--env', envArg);
     });
+
+    if (envFile) {
+      args.splice(0, 0, '--env-file', envFile);
+    }
 
     if (rm) {
       args.splice(0, 0, '--rm');


### PR DESCRIPTION
This PR adds support for the `envFile` option (`--env-file` argument) when running a Docker container.

### Commits

- ✨ Support the envFile options for DockerService.run
- 📝 Update changelog