### PR TITLE
🔊 Log emulators configuration when starting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 - Define the `OpenApiGenerateSpecification` workspace function (`cs openapi genSpec`) and provide its workspace-level implementation, which merges all OpenAPI specifications in a single file.
 - Support the `envFile` options for `DockerService.run`.
+- Log the emulators configuration after starting them using `cs emulators start`.
 
 ## v0.14.1 (2023-08-04)
 

--- a/src/functions/emulator-start-many.ts
+++ b/src/functions/emulator-start-many.ts
@@ -42,15 +42,20 @@ export class EmulatorStartManyForAll extends EmulatorStartMany {
     const emulatorResults = await Promise.all(
       emulatorStarts.map((emulatorStart) => emulatorStart._call(context)),
     );
+    result.emulatorNames = emulatorResults.map((r) => r.name);
+    result.configuration = Object.assign(
+      {},
+      ...emulatorResults.map((r) => r.configuration),
+    );
 
-    return emulatorResults.reduce((results, result) => {
-      results.emulatorNames.push(result.name);
-      results.configuration = {
-        ...results.configuration,
-        ...result.configuration,
-      };
-      return results;
-    }, result);
+    if (Object.keys(result.configuration).length > 0) {
+      const confStr = Object.entries(result.configuration)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('\n');
+      context.logger.info(`🔧 Configuration for emulators:\n${confStr}`);
+    }
+
+    return result;
   }
 
   _supports(): boolean {


### PR DESCRIPTION
This PR adds logs to the `cs emulators start` command, such that the configuration for all started emulators is shown.

### Commits

- 🔊 Log the emulators configuration after starting them
- 📝 Update changelog