### PR TITLE
🔊 Suggest Docker authorization issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 - Define the `OpenApiGenerateSpecification` workspace function (`cs openapi genSpec`) and provide its workspace-level implementation, which merges all OpenAPI specifications in a single file.
 - Support the `envFile` options for `DockerService.run`.
 - Log the emulators configuration after starting them using `cs emulators start`.
+- Suggest an authorization issue when failing to push a Docker image for a service container.
 
 ## v0.14.1 (2023-08-04)
 


### PR DESCRIPTION
This PR provides a hint when failing to push a Docker image (a service container artefact). It indicates the most probable reason for the failure, which is that Docker has not been configured (authorised) to push to the remote registry. This can help debugging such problems.

### Commits

- 🔊 Suggest authorization issue when failing to push a Docker image
- 📝 Update changelog