### PR TITLE
🔖 Prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.0 (2023-09-18)
+
 Features:
 
 - Support overriding the OpenAPI version in the `openApi.global` document.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Support overriding the OpenAPI version in the `openApi.global` document.
- Support generating the list of OpenAPI servers from the list of environments.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.16.0