### PR TITLE
✨ `ServiceContainerBuilderService` and build secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `serviceContainer.buildFile` and `serviceContainer.buildSecrets` configuration parameters.
+- Implement the `ServiceContainerBuilderService`.
+
 ## v0.16.0 (2023-09-18)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This module implements some [services](./src/services/) used by itself, but whic
 - `GitService`: Runs `git` commands using the `ProcessService`.
 - `DockerService`: Runs `docker` commands using the `ProcessService`.
 - `DockerEmulatorService`: Provides a normalized way to starting and stopping containerized emulators. Also provides a way to wait for an emulator exposing an HTTP endpoint.
+- `ServiceContainerBuilderService`: Provides the base logic to build service container images (using the `DockerService`). Language-specific modules can use this service and customize build parameters.
 
 ## 🧱 Infrastructure processors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,24 +11,24 @@
       "dependencies": {
         "@causa/cli": ">= 0.4.0 < 1.0.0",
         "@causa/workspace": ">= 0.12.0 < 1.0.0",
-        "axios": "^1.5.0",
+        "axios": "^1.5.1",
         "class-validator": "^0.14.0",
         "js-yaml": "^4.1.0",
         "openapi-merge": "^1.3.2",
-        "pino": "^8.15.1"
+        "pino": "^8.15.3"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.2",
         "@types/jest": "^29.5.5",
         "@types/js-yaml": "^4.0.6",
-        "@types/node": "^18.17.17",
-        "@typescript-eslint/eslint-plugin": "^6.7.0",
-        "eslint": "^8.49.0",
+        "@types/node": "^18.18.1",
+        "@typescript-eslint/eslint-plugin": "^6.7.3",
+        "eslint": "^8.50.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.1",
-        "rimraf": "^5.0.1",
+        "rimraf": "^5.0.5",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
@@ -153,22 +153,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
-      "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+      "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
+        "@babel/generator": "^7.23.0",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.20",
-        "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.16",
+        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helpers": "^7.23.0",
+        "@babel/parser": "^7.23.0",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.20",
-        "@babel/types": "^7.22.19",
-        "convert-source-map": "^1.7.0",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
@@ -182,12 +182,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
-    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -198,12 +192,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -247,13 +241,13 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -284,9 +278,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.20.tgz",
-      "integrity": "sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -363,14 +357,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
+      "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -462,9 +456,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -665,19 +659,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
-      "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
+        "@babel/generator": "^7.23.0",
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.19",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -695,13 +689,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-      "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.19",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -789,9 +783,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
-      "integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
+      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -821,9 +815,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
-      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1595,9 +1589,9 @@
       }
     },
     "node_modules/@types/graceful-fs": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
-      "integrity": "sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
+      "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1610,18 +1604,18 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -1650,20 +1644,20 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
     },
     "node_modules/@types/node": {
-      "version": "18.17.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.17.tgz",
-      "integrity": "sha512-cOxcXsQ2sxiwkykdJqvyFS+MLQPLvIdwh5l6gNg8qF6s+C7XSkEWOZjK+XhUZd+mYvHV/180g2cnCcIl4l06Pw==",
+      "version": "18.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
+      "integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -1673,36 +1667,36 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.1.tgz",
-      "integrity": "sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A=="
+      "version": "13.11.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.2.tgz",
+      "integrity": "sha512-nIKVVQKT6kGKysnNt+xLobr+pFJNssJRi2s034wgWeFBUx01fI8BeHTW2TcRp7VcFu9QCYG8IlChTuovcm0oKQ=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.26.tgz",
+      "integrity": "sha512-Y3vDy2X6zw/ZCumcwLpdhM5L7jmyGpmBCTYMHDLqT2IKVMYRRLdv6ZakA+wxhra6Z/3bwhNbNl9bDGXaFU+6rw==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz",
-      "integrity": "sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.3.tgz",
+      "integrity": "sha512-vntq452UHNltxsaaN+L9WyuMch8bMd9CqJ3zhzTPXXidwbf5mqqKCVXEuvRZUqLJSTLeWE65lQwyXsRGnXkCTA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.7.0",
-        "@typescript-eslint/type-utils": "6.7.0",
-        "@typescript-eslint/utils": "6.7.0",
-        "@typescript-eslint/visitor-keys": "6.7.0",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/type-utils": "6.7.3",
+        "@typescript-eslint/utils": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1728,16 +1722,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
-      "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.3.tgz",
+      "integrity": "sha512-TlutE+iep2o7R8Lf+yoer3zU6/0EAUc8QIBB3GYBc1KGz4c4TRm83xwXUZVPlZ6YCLss4r77jbu6j3sendJoiQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.7.0",
-        "@typescript-eslint/types": "6.7.0",
-        "@typescript-eslint/typescript-estree": "6.7.0",
-        "@typescript-eslint/visitor-keys": "6.7.0",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1757,13 +1751,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
-      "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.3.tgz",
+      "integrity": "sha512-wOlo0QnEou9cHO2TdkJmzF7DFGvAKEnB82PuPNHpT8ZKKaZu6Bm63ugOTn9fXNJtvuDPanBc78lGUGGytJoVzQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.0",
-        "@typescript-eslint/visitor-keys": "6.7.0"
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1774,13 +1768,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz",
-      "integrity": "sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.3.tgz",
+      "integrity": "sha512-Fc68K0aTDrKIBvLnKTZ5Pf3MXK495YErrbHb1R6aTpfK5OdSFj0rVN7ib6Tx6ePrZ2gsjLqr0s98NG7l96KSQw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.7.0",
-        "@typescript-eslint/utils": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "@typescript-eslint/utils": "6.7.3",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1801,9 +1795,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
-      "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.3.tgz",
+      "integrity": "sha512-4g+de6roB2NFcfkZb439tigpAMnvEIg3rIjWQ+EM7IBaYt/CdJt6em9BJ4h4UpdgaBWdmx2iWsafHTrqmgIPNw==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1814,13 +1808,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
-      "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.3.tgz",
+      "integrity": "sha512-YLQ3tJoS4VxLFYHTw21oe1/vIZPRqAO91z6Uv0Ss2BKm/Ag7/RVQBcXTGcXhgJMdA4U+HrKuY5gWlJlvoaKZ5g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.0",
-        "@typescript-eslint/visitor-keys": "6.7.0",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1870,17 +1864,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
-      "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.3.tgz",
+      "integrity": "sha512-vzLkVder21GpWRrmSR9JxGZ5+ibIUSudXlW52qeKpzUEQhRSmyZiVDDj3crAth7+5tmN1ulvgKaCU2f/bPRCzg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.7.0",
-        "@typescript-eslint/types": "6.7.0",
-        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/typescript-estree": "6.7.3",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1895,12 +1889,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
-      "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.3.tgz",
+      "integrity": "sha512-HEVXkU9IB+nk9o63CeICMHxFWbHWr3E1mpilIQBe9+7L/lH97rleFLVtYsfnWB+JVMaiFnEaxvknvmIzX+CqVg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/types": "6.7.3",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2075,9 +2069,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -2276,9 +2270,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "funding": [
         {
@@ -2295,10 +2289,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2391,9 +2385,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001535",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001535.tgz",
-      "integrity": "sha512-48jLyUkiWFfhm/afF7cQPqPjaUmSraEhK4j+FCTJpgnGGEZHqyLe3hmWH7lIooZdSzXL0ReMvHz0vKDoTBsrwg==",
+      "version": "1.0.30001542",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001542.tgz",
+      "integrity": "sha512-UrtAXVcj1mvPBFQ4sKd38daP8dEcXXr5sQe6QNNinaPd0iA/cxg9/l3VrSdL73jgw5sKyuQ6jNgiKO12W3SsVA==",
       "dev": true,
       "funding": [
         {
@@ -2871,9 +2865,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.523",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.523.tgz",
-      "integrity": "sha512-9AreocSUWnzNtvLcbpng6N+GkXnCcBR80IQkxRC9Dfdyg4gaWNUPBujAHUpKkiUkoSoR9UlhA4zD/IgBklmhzg==",
+      "version": "1.4.537",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.537.tgz",
+      "integrity": "sha512-W1+g9qs9hviII0HAwOdehGYkr+zt7KKdmCcJcjH0mYg6oL8+ioT3Skjmt7BLoAQqXhjf40AXd+HlR4oAWMlXjA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2933,15 +2927,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
-      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.49.0",
+        "@eslint/js": "8.50.0",
         "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -3351,9 +3345,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -3507,9 +3501,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3948,9 +3942,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.3.tgz",
-      "integrity": "sha512-R2bUw+kVZFS/h1AZqBKrSgDmdmjApzgY0AlCPumopFiAlbUxE2gf+SCuBzQ0cP5hHmUmFYF5yw55T97Th5Kstg==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4708,9 +4702,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.44",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.44.tgz",
-      "integrity": "sha512-svlRdNBI5WgBjRC20GrCfbFiclbF0Cx+sCcQob/C1r57nsoq0xg8r65QbTyVyweQIlB33P+Uahyho6EMYgcOyQ=="
+      "version": "1.10.45",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.45.tgz",
+      "integrity": "sha512-eeHcvGafEYCaKB4fo2uBINfG7j7PcGwBHUaTVfbwl/6KcjCgIKNlIOsSXVRp9BH10NQwmvvk+nQ1e/Yp4BGB7w=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -4869,9 +4863,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5167,9 +5161,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.1.tgz",
-      "integrity": "sha512-Cp4QzUQrvWCRJaQ8Lzv0mJzXVk4z2jlq8JNKMGaixC2Pz5L4l2p95TkuRvYbrEbe85NQsDKrAd4zalf7Ml6WiA==",
+      "version": "8.15.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.3.tgz",
+      "integrity": "sha512-wDds1+DH8VaREe4fpLEKttGnDoLiX3KR3AP5bHsrRwEZ93y+Z/HFC03zkGSxpIGWKDHg24sloVqGcIWoLCkTLQ==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -5411,9 +5405,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.3.tgz",
-      "integrity": "sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
       "dev": true,
       "funding": [
         {
@@ -5570,15 +5564,15 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
-      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
       "dev": true,
       "dependencies": {
-        "glob": "^10.2.5"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": ">=14"
@@ -5597,19 +5591,19 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
-      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
+        "jackspeak": "^2.3.5",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
         "path-scurry": "^1.10.1"
       },
       "bin": {
-        "glob": "dist/cjs/src/bin.js"
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5777,9 +5771,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
-      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.4.0.tgz",
+      "integrity": "sha512-zSe9QQW30nPzjkSJ0glFQO5T9lHsk39tz+2bAAwCj8CNgEG8ItZiX7Wb2ZgA8I04dwRGCcf1m3ABJa8AYm12Fw==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -6213,9 +6207,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -30,24 +30,24 @@
   "dependencies": {
     "@causa/cli": ">= 0.4.0 < 1.0.0",
     "@causa/workspace": ">= 0.12.0 < 1.0.0",
-    "axios": "^1.5.0",
+    "axios": "^1.5.1",
     "class-validator": "^0.14.0",
     "js-yaml": "^4.1.0",
     "openapi-merge": "^1.3.2",
-    "pino": "^8.15.1"
+    "pino": "^8.15.3"
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.2",
     "@types/jest": "^29.5.5",
     "@types/js-yaml": "^4.0.6",
-    "@types/node": "^18.17.17",
-    "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "eslint": "^8.49.0",
+    "@types/node": "^18.18.1",
+    "@typescript-eslint/eslint-plugin": "^6.7.3",
+    "eslint": "^8.50.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.1",
-    "rimraf": "^5.0.1",
+    "rimraf": "^5.0.5",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"

--- a/src/configurations/index.ts
+++ b/src/configurations/index.ts
@@ -4,4 +4,7 @@ export { EventsConfiguration } from './events.js';
 export { InfrastructureConfiguration } from './infrastructure-project.js';
 export { OpenApiConfiguration } from './openapi.js';
 export { ServerlessFunctionsConfiguration } from './serverless-functions-project.js';
-export { ServiceContainerConfiguration } from './service-container-project.js';
+export {
+  BuildSecret,
+  ServiceContainerConfiguration,
+} from './service-container-project.js';

--- a/src/configurations/service-container-project.ts
+++ b/src/configurations/service-container-project.ts
@@ -1,4 +1,22 @@
 /**
+ * The definition of a secret to pass to the Docker build command.
+ */
+export type BuildSecret =
+  | {
+      /**
+       * The source file for the secret.
+       */
+      readonly file: string;
+    }
+  | {
+      /**
+       * The value of the secret.
+       * In this case the value will be passed as an environment variable to the Docker command.
+       */
+      readonly value: string;
+    };
+
+/**
  * Configuration for service container projects.
  */
 export type ServiceContainerConfiguration = {
@@ -24,10 +42,22 @@ export type ServiceContainerConfiguration = {
     readonly platform?: string;
 
     /**
+     * The Dockerfile used to build the image for the service.
+     * Language-specific modules may provide a default value for this.
+     */
+    readonly buildFile?: string;
+
+    /**
      * Docker build arguments when building the image for the service.
      * Supports rendering.
      */
     readonly buildArgs?: Record<string, string>;
+
+    /**
+     * Docker build `--secret` arguments to pass when building the image for the service.
+     * Supports rendering.
+     */
+    readonly buildSecrets?: Record<string, BuildSecret>;
 
     /**
      * The endpoints exposed by the service.

--- a/src/services/docker.spec.ts
+++ b/src/services/docker.spec.ts
@@ -51,6 +51,7 @@ describe('DockerService', () => {
         file: 'MyDockerfile',
         platform: 'powerpc',
         buildArgs: { SOME_ARG: 'VALUE1', SOME_OTHER_ARG: undefined },
+        secrets: { secret1: { source: '/some/file' }, secret2: { env: '🗝️' } },
         tags: ['tag1', 'tag2'],
       });
 
@@ -64,6 +65,8 @@ describe('DockerService', () => {
       expect(actualArgs).toContain('--platform powerpc');
       expect(actualArgs).toContain('--build-arg SOME_ARG=VALUE1');
       expect(actualArgs).toContain('--build-arg SOME_OTHER_ARG');
+      expect(actualArgs).toContain('--secret id=secret1,source=/some/file');
+      expect(actualArgs).toContain('--secret id=secret2,env=🗝️');
       expect(actualArgs).toContain('--tag tag1');
       expect(actualArgs).toContain('--tag tag2');
     });

--- a/src/services/docker.ts
+++ b/src/services/docker.ts
@@ -118,6 +118,26 @@ export class DockerService {
       buildArgs?: Record<string, string | undefined>;
 
       /**
+       * Secrets passed to the Dockerfile.
+       * Keys are secret IDs and must be provided, contrary to the Docker command line.
+       */
+      secrets?: Record<
+        string,
+        | {
+            /**
+             * The secret filename.
+             */
+            source: string;
+          }
+        | {
+            /**
+             * The secret environment variable.
+             */
+            env: string;
+          }
+      >;
+
+      /**
        * A list of tags to assign to the image.
        */
       tags?: string[];
@@ -143,6 +163,19 @@ export class DockerService {
           '--build-arg',
           value === undefined ? key : `${key}=${value}`,
         ]),
+      );
+    }
+
+    if (options.secrets) {
+      args.push(
+        ...Object.entries(options.secrets).flatMap(([id, secret]) => {
+          return [
+            '--secret',
+            'source' in secret
+              ? `id=${id},source=${secret.source}`
+              : `id=${id},env=${secret.env}`,
+          ];
+        }),
       );
     }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -14,3 +14,4 @@ export {
   SpawnOptions,
   SpawnedProcessResult,
 } from './process.js';
+export { ServiceContainerBuilderService } from './service-container-builder.js';

--- a/src/services/service-container-builder.spec.ts
+++ b/src/services/service-container-builder.spec.ts
@@ -1,0 +1,116 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import { DockerService } from './docker.js';
+import { ServiceContainerBuilderService } from './service-container-builder.js';
+
+describe('ServiceContainerBuilderService', () => {
+  let context: WorkspaceContext;
+  let service: ServiceContainerBuilderService;
+  let dockerService: DockerService;
+  let buildSpy: jest.SpiedFunction<DockerService['build']>;
+
+  beforeEach(() => {
+    ({ context } = createContext({
+      rootPath: '/some-root',
+      configuration: {
+        workspace: { name: '🏷️' },
+        serviceContainer: {
+          architecture: 'amd64',
+          buildFile: 'some-dockerfile',
+          buildArgs: { SOME_ENV: { $format: '🍬' } },
+          buildSecrets: {
+            MY_SECRET: { file: 'some-file' },
+            OTHER_SECRET: { value: { $format: '🙊' } },
+          },
+        },
+      },
+    }));
+    service = context.service(ServiceContainerBuilderService);
+    dockerService = context.service(DockerService);
+    buildSpy = jest.spyOn(dockerService, 'build').mockResolvedValue({} as any);
+  });
+
+  describe('build', () => {
+    it('should build the image using the configuration', async () => {
+      await service.build('/some-path', 'some-image', '/some-default-file');
+
+      expect(dockerService.build).toHaveBeenCalledWith('/some-path', {
+        file: '/some-root/some-dockerfile',
+        platform: 'amd64',
+        buildArgs: { SOME_ENV: '🍬' },
+        secrets: {
+          MY_SECRET: { source: '/some-root/some-file' },
+          OTHER_SECRET: { env: expect.any(String) },
+        },
+        tags: ['some-image'],
+        environment: expect.any(Object),
+      });
+      const actualOptions = buildSpy.mock.calls[0][1];
+      const otherSecretEnv = (actualOptions as any).secrets.OTHER_SECRET.env;
+      expect(otherSecretEnv).not.toEqual('🙊');
+      expect(actualOptions?.environment).toEqual({
+        ...process.env,
+        [otherSecretEnv]: '🙊',
+      });
+    });
+
+    it('should include the base build configuration', async () => {
+      await service.build('/some-path', 'some-image', '/some-default-file', {
+        baseBuildArgs: { SOME_BASE_ENV: '🍭' },
+        baseBuildSecrets: {
+          BASE_SECRET: { file: '/some-base-file' },
+          MY_SECRET: { value: '❌' },
+          YET_ANOTHER: { value: '🗝️' },
+        },
+      });
+
+      expect(dockerService.build).toHaveBeenCalledWith('/some-path', {
+        file: '/some-root/some-dockerfile',
+        platform: 'amd64',
+        buildArgs: { SOME_ENV: '🍬', SOME_BASE_ENV: '🍭' },
+        secrets: {
+          MY_SECRET: { source: '/some-root/some-file' },
+          BASE_SECRET: { source: '/some-base-file' },
+          OTHER_SECRET: { env: expect.any(String) },
+          YET_ANOTHER: { env: expect.any(String) },
+        },
+        tags: ['some-image'],
+        environment: expect.any(Object),
+      });
+      const actualOptions = buildSpy.mock.calls[0][1];
+      const otherSecretEnv = (actualOptions as any).secrets.OTHER_SECRET.env;
+      const yetAnotherEnv = (actualOptions as any).secrets.YET_ANOTHER.env;
+      expect(otherSecretEnv).not.toEqual('🙊');
+      expect(yetAnotherEnv).not.toEqual('🗝️');
+      expect(otherSecretEnv).not.toEqual(yetAnotherEnv);
+      expect(actualOptions?.environment).toEqual({
+        ...process.env,
+        [otherSecretEnv]: '🙊',
+        [yetAnotherEnv]: '🗝️',
+      });
+    });
+
+    it('should use the default file if no file is configured', async () => {
+      ({ context } = createContext({
+        rootPath: '/some-root',
+        configuration: { workspace: { name: '🏷️' } },
+      }));
+      service = context.service(ServiceContainerBuilderService);
+      dockerService = context.service(DockerService);
+      jest.spyOn(dockerService, 'build').mockResolvedValue({} as any);
+
+      await service.build('/some-path', 'some-image', '/some-default-file');
+
+      expect(dockerService.build).toHaveBeenCalledWith('/some-path', {
+        file: '/some-default-file',
+        platform: undefined,
+        buildArgs: {},
+        secrets: {},
+        tags: ['some-image'],
+        environment: process.env,
+      });
+    });
+  });
+});

--- a/src/services/service-container-builder.ts
+++ b/src/services/service-container-builder.ts
@@ -1,0 +1,123 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { randomBytes } from 'crypto';
+import { resolve } from 'path';
+import {
+  BuildSecret,
+  ServiceContainerConfiguration,
+} from '../configurations/index.js';
+import { DockerService } from './docker.js';
+
+/**
+ * A service providing the base logic to build service container Docker images.
+ * It relies on several options that are common to all service container projects.
+ * Additional language options can be provided by the workspace function using this service.
+ */
+export class ServiceContainerBuilderService {
+  /**
+   * The underlying Docker service.
+   */
+  private readonly dockerService: DockerService;
+
+  /**
+   * The root path of the workspace.
+   */
+  readonly rootPath: string;
+
+  /**
+   * The processor architecture used when building Docker images.
+   */
+  readonly platform: string | undefined;
+
+  /**
+   * The Dockerfile used to build the image.
+   */
+  readonly file: string | undefined;
+
+  /**
+   * Docker build arguments when building the image.
+   */
+  readonly buildArgs: Promise<Record<string, string> | undefined>;
+
+  /**
+   * Docker build `--secret` arguments to pass when building the image.
+   */
+  readonly buildSecrets: Promise<Record<string, BuildSecret> | undefined>;
+
+  constructor(context: WorkspaceContext) {
+    this.dockerService = context.service(DockerService);
+    this.rootPath = context.rootPath;
+
+    const serviceContainerConf =
+      context.asConfiguration<ServiceContainerConfiguration>();
+    this.platform = serviceContainerConf.get('serviceContainer.architecture');
+    const file = serviceContainerConf.get('serviceContainer.buildFile');
+    this.file = file ? resolve(this.rootPath, file) : undefined;
+    this.buildArgs = serviceContainerConf.getAndRender(
+      'serviceContainer.buildArgs',
+    );
+    this.buildSecrets = serviceContainerConf.getAndRender(
+      'serviceContainer.buildSecrets',
+    );
+  }
+
+  /**
+   * Builds the Docker image for a service container.
+   *
+   * @param path The path to the root of the Docker context (e.g. the project root).
+   * @param imageName The name (tag) of the image to build.
+   * @param defaultFile The default Dockerfile to use, is `serviceContainer.buildFile` is not set.
+   * @param options Additional options to pass to the Docker build command.
+   */
+  async build(
+    path: string,
+    imageName: string,
+    defaultFile: string,
+    options: {
+      /**
+       * Additional build arguments to pass to the Docker build command.
+       * They will be merged with (and possibly overridden by) the `serviceContainer.buildArgs` configuration.
+       */
+      baseBuildArgs?: Record<string, string>;
+
+      /**
+       * Additional secrets to pass to the Docker build command.
+       * They will be merged with (and possibly overridden by) the `serviceContainer.buildSecrets` configuration.
+       */
+      baseBuildSecrets?: Record<string, BuildSecret>;
+    } = {},
+  ): Promise<void> {
+    const file = this.file ?? defaultFile;
+
+    const buildArgs = {
+      ...options.baseBuildArgs,
+      ...(await this.buildArgs),
+    };
+
+    const buildSecrets = {
+      ...options.baseBuildSecrets,
+      ...(await this.buildSecrets),
+    };
+    const environment = { ...process.env };
+    const secrets = Object.fromEntries(
+      Object.entries(buildSecrets).map(([key, secret]) => {
+        if ('file' in secret) {
+          const source = resolve(this.rootPath, secret.file);
+          return [key, { source }];
+        }
+
+        const env = randomBytes(3).toString('hex');
+        environment[env] = secret.value;
+        return [key, { env }];
+      }),
+    );
+
+    await this.dockerService.build(path, {
+      file,
+      platform: this.platform,
+      buildArgs,
+      secrets,
+      tags: [imageName],
+      environment,
+    });
+  }
+}


### PR DESCRIPTION
This PR implements the `ServiceContainerBuilderService`, which also supports two new configuration parameters: `serviceContainer.buildFile` and `serviceContainer.buildSecrets`.

### Commits

- ⬆️ Upgrade dependencies
- ✨ Define buildSecrets and buildFile for the service container configuration
- ✨ Support the secrets option for DockerService.build
- ✨ Implement the ServiceContainerBuilderService
- 📝 Update changelog
- 📝 Document the ServiceContainerBuilderService