### PR TITLE
🔖 Prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.19.0 (2023-10-31)
+
 Breaking changes:
 
 - Language-specific modules are no longer expected to implement `EventTopicGenerateCode` directly, at least for JSONSchema topic definitions. `EventTopicGenerateCode` is now implemented by this module using [quicktype](https://github.com/glideapps/quicktype). Language modules should implement `EventTopicMakeCodeGenerationTargetLanguage` instead and return a quicktype `TargetLanguage`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Language-specific modules are no longer expected to implement `EventTopicGenerateCode` directly, at least for JSONSchema topic definitions. `EventTopicGenerateCode` is now implemented by this module using [quicktype](https://github.com/glideapps/quicktype). Language modules should implement `EventTopicMakeCodeGenerationTargetLanguage` instead and return a quicktype `TargetLanguage`.

Features:

- Implement and expose [quicktype-related utilities](./src/code-generation/), meant to be used by language-specific Causa modules for code generation.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.19.0