### PR TITLE
🐛 Handle Causa attributes being combined with a null type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Handle Causa attributes being combined with a null type during JSONSchema-based code generation.
+
 ## v0.19.0 (2023-10-31)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.2",
-        "@types/jest": "^29.5.6",
+        "@types/jest": "^29.5.7",
         "@types/js-yaml": "^4.0.8",
-        "@types/node": "^18.18.7",
-        "@typescript-eslint/eslint-plugin": "^6.9.0",
+        "@types/node": "^18.18.8",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
         "eslint": "^8.52.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.6.tgz",
-      "integrity": "sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==",
+      "version": "29.5.7",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.7.tgz",
+      "integrity": "sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -1655,9 +1655,9 @@
       "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
     },
     "node_modules/@types/node": {
-      "version": "18.18.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.7.tgz",
-      "integrity": "sha512-bw+lEsxis6eqJYW8Ql6+yTqkE6RuFtsQPSe5JxXbqYRFQEER5aJA9a5UH9igqDWm3X4iLHIKOHlnAXLM4mi7uQ==",
+      "version": "18.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
+      "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1701,16 +1701,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz",
-      "integrity": "sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
+      "integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.9.0",
-        "@typescript-eslint/type-utils": "6.9.0",
-        "@typescript-eslint/utils": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/scope-manager": "6.9.1",
+        "@typescript-eslint/type-utils": "6.9.1",
+        "@typescript-eslint/utils": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1736,16 +1736,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
-      "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
+      "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.9.0",
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/typescript-estree": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/scope-manager": "6.9.1",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/typescript-estree": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1765,13 +1765,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
-      "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
+      "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0"
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1782,13 +1782,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz",
-      "integrity": "sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
+      "integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.9.0",
-        "@typescript-eslint/utils": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.1",
+        "@typescript-eslint/utils": "6.9.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1809,9 +1809,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
-      "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
+      "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1822,13 +1822,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
-      "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
+      "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1878,17 +1878,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz",
-      "integrity": "sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
+      "integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.9.0",
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/scope-manager": "6.9.1",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/typescript-estree": "6.9.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1903,12 +1903,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
-      "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
+      "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/types": "6.9.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2410,9 +2410,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001558",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001558.tgz",
-      "integrity": "sha512-/Et7DwLqpjS47JPEcz6VnxU9PwcIdVi0ciLXRWBQdj1XFye68pSQYpV0QtPTfUKWuOaEig+/Vez2l74eDc1tPQ==",
+      "version": "1.0.30001559",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
+      "integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
       "dev": true,
       "funding": [
         {
@@ -2903,9 +2903,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.569",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.569.tgz",
-      "integrity": "sha512-LsrJjZ0IbVy12ApW3gpYpcmHS3iRxH4bkKOW98y1/D+3cvDUWGcbzbsFinfUS8knpcZk/PG/2p/RnkMCYN7PVg==",
+      "version": "1.4.574",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.574.tgz",
+      "integrity": "sha512-bg1m8L0n02xRzx4LsTTMbBPiUd9yIR+74iPtS/Ao65CuXvhVZHP0ym1kSdDG3yHFDXqHQQBKujlN1AQ8qZnyFg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5483,9 +5483,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.2",
-    "@types/jest": "^29.5.6",
+    "@types/jest": "^29.5.7",
     "@types/js-yaml": "^4.0.8",
-    "@types/node": "^18.18.7",
-    "@typescript-eslint/eslint-plugin": "^6.9.0",
+    "@types/node": "^18.18.8",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",

--- a/src/code-generation/causa-attribute-kind.spec.ts
+++ b/src/code-generation/causa-attribute-kind.spec.ts
@@ -1,0 +1,22 @@
+import { TypeAttributeKind } from 'quicktype-core';
+import { causaTypeAttributeKind } from './causa-attribute-kind.js';
+
+describe('causaTypeAttributeKind', () => {
+  it('should return the attributes for the first type', () => {
+    const expectedAttribute = {};
+
+    const actualCombined = (
+      causaTypeAttributeKind as TypeAttributeKind<any>
+    ).combine([expectedAttribute, {}]);
+
+    expect(actualCombined).toBe(expectedAttribute);
+  });
+
+  it('should not return the attribute when making an inferred type', () => {
+    const actualInferred = (
+      causaTypeAttributeKind as TypeAttributeKind<any>
+    ).makeInferred({});
+
+    expect(actualInferred).toBeUndefined();
+  });
+});

--- a/src/code-generation/causa-attribute-kind.ts
+++ b/src/code-generation/causa-attribute-kind.ts
@@ -33,11 +33,15 @@ export class CausaTypeAttributeKind extends TypeAttributeKind<CausaAttribute> {
     super('causa');
   }
 
-  combine(): CausaAttribute | undefined {
-    return undefined;
+  combine(attributes: CausaAttribute[]): CausaAttribute | undefined {
+    // This handles unions of the class (object) type with the `null` type.
+    // This is counter-intuitive because `null` is not an object type and won't have any attributes.
+    // However tests prove this is needed.
+    return attributes[0];
   }
 
   makeInferred(): CausaAttribute | undefined {
+    // Trying to handle the union with a `null` type here does not work, or at least not in all cases.
     return undefined;
   }
 

--- a/src/functions/event-topic/generate-code-json-schema.spec.ts
+++ b/src/functions/event-topic/generate-code-json-schema.spec.ts
@@ -124,15 +124,21 @@ describe('EventTopicGenerateCodeForJsonSchema', () => {
     await writeFile(
       schemaFilePath,
       JSON.stringify({
-        title: 'MyDummyObject',
-        type: 'object',
-        causa: { someObjAttribute: '🎉' },
-        properties: {
-          myProp: {
-            type: 'string',
-            causa: { somePropAttribute: '🔧' },
+        // Having a union type here helps test `CausaTypeAttributeKind.combine`, which should propagate attributes.
+        oneOf: [
+          { type: 'null' },
+          {
+            title: 'MyDummyObject',
+            type: 'object',
+            causa: { someObjAttribute: '🎉' },
+            properties: {
+              myProp: {
+                type: 'string',
+                causa: { somePropAttribute: '🔧' },
+              },
+            },
           },
-        },
+        ],
       }),
     );
     const definitions: EventTopicDefinition[] = [

--- a/src/functions/event-topic/generate-code-json-schema.ts
+++ b/src/functions/event-topic/generate-code-json-schema.ts
@@ -64,6 +64,7 @@ export class EventTopicGenerateCodeForJsonSchema extends EventTopicGenerateCode 
     const result = await quicktype({ inputData, lang });
     const outputLines = result.lines.join('\n');
 
+    context.logger.info('🔨 Writing generated code to output file.');
     await lang.writeFile(outputLines);
   }
 

--- a/src/functions/event-topic/generate-code-json-schema.ts
+++ b/src/functions/event-topic/generate-code-json-schema.ts
@@ -31,14 +31,14 @@ export class EventTopicGenerateCodeForJsonSchema extends EventTopicGenerateCode 
       causaJsonSchemaAttributeProducer,
     ]);
 
-    const sources: JSONSchemaSourceData[] = await Promise.all(
-      this.definitions.map(async (definition) => ({
+    const sources: JSONSchemaSourceData[] = this.definitions.map(
+      (definition) => ({
         // There is an inconsistent behavior in naming when passing a single schema file to quicktype.
         // Setting the name as `undefined` ensures the `title` JSONSchema attribute is used as the class name for the
         // top-level type in the schema.
         name: undefined as any,
         uris: [definition.schemaFilePath],
-      })),
+      }),
     );
 
     for (const source of sources) {

--- a/src/functions/event-topic/generate-code-referenced-in-project.ts
+++ b/src/functions/event-topic/generate-code-referenced-in-project.ts
@@ -28,7 +28,11 @@ export class MissingEventTopicDefinitionsError extends Error {
  */
 export class EventTopicGenerateCodeReferencedInProjectForAll extends EventTopicGenerateCodeReferencedInProject {
   async _call(context: WorkspaceContext): Promise<string[]> {
-    context.getProjectPathOrThrow();
+    const projectPath = context.getProjectPathOrThrow();
+
+    context.logger.info(
+      `🔨 Generating code for event topics referenced by project at path '${projectPath}'.`,
+    );
 
     const topicDefinitions = await context.call(EventTopicList, {});
     const existingTopicIds = new Set(topicDefinitions.map((d) => d.id));


### PR DESCRIPTION
This PR fixes a bug where custom `causa` attributes in a JSONSchema would be lost when combining a referenced type with a `null` type (using `oneOf`).

Also, some logs are added.

### Commits

- ⬆️ Upgrade dependencies
- 🐛 Handle Causa attributes being combined with a null type
- ♻️ Remove unnecessary asynchronous code
- 🔊 Add logs to code generation functions
- 📝 Update changelog