### PR TITLE
🔖 Prepare v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.19.1 (2023-11-02)
+
 Fixes:
 
 - Handle Causa attributes being combined with a null type during JSONSchema-based code generation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Handle Causa attributes being combined with a null type during JSONSchema-based code generation.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.19.1