### PR TITLE
🔖 Prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.20.0 (2024-05-17)
+
 Breaking change:
 
 - Drop support for Node.js 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.5.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Drop support for Node.js 16.

Chore:

- Upgrade dependencies.

### Commits

- **🔖 Set version to 0.20.0**
- **📝 Update changelog**