### PR TITLE
🔖 Prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.21.0 (2024-05-27)
+
 Breaking change:
 
 - Ignore symbolic links in the `JsonFilesEventSource`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.5.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Ignore symbolic links in the `JsonFilesEventSource`.

### Commits

- **🔖 Set version to 0.21.0**
- **📝 Update changelog**