### PR TITLE
💥 `GitService` improvements and breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking change:
+
+- Change `GitService.diff` option to `commits`, to explicitly handle several commits.
+
+Features:
+
+- Implement `GitService.getRepositoryRootPath`.
+
 ## v0.21.0 (2024-05-27)
 
 Breaking change:

--- a/src/services/git.spec.ts
+++ b/src/services/git.spec.ts
@@ -87,7 +87,7 @@ describe('GitService', () => {
         .mockResolvedValueOnce(expectedResult);
 
       const actualResult = await service.diff({
-        commit: 'abcd',
+        commits: ['abcd'],
         cached: true,
         nameOnly: true,
         paths: ['a', 'b'],
@@ -112,7 +112,7 @@ describe('GitService', () => {
         .mockResolvedValueOnce({ code: 0, stdout: expectedDiff });
 
       const actualDiff = await service.filesDiff({
-        commit: 'abcd..efgh',
+        commits: ['abcd', 'efgh'],
         cached: true,
         paths: ['a', 'b'],
       });
@@ -123,7 +123,7 @@ describe('GitService', () => {
       expect(actualCommand).toEqual('diff');
       expect(actualArgs).toContain('--name-only');
       expect(actualArgs).toContain('--cached');
-      expect(actualArgs).toEndWith(' abcd..efgh -- a b');
+      expect(actualArgs).toEndWith(' abcd efgh -- a b');
       expect(options).toEqual({ capture: { stdout: true }, logging: null });
     });
   });

--- a/src/services/git.spec.ts
+++ b/src/services/git.spec.ts
@@ -43,6 +43,42 @@ describe('GitService', () => {
     });
   });
 
+  describe('getRepositoryRootPath', () => {
+    it('should call git rev-parse', async () => {
+      const expectedRootPath = '/root/dir';
+      jest
+        .spyOn(service, 'git')
+        .mockResolvedValueOnce({ code: 0, stdout: `${expectedRootPath}\n` });
+
+      const actualRootPath = await service.getRepositoryRootPath();
+
+      expect(actualRootPath).toEqual(expectedRootPath);
+      expect(service.git).toHaveBeenCalledExactlyOnceWith(
+        'rev-parse',
+        ['--show-toplevel'],
+        expect.anything(),
+      );
+    });
+
+    it('should run from the specified directory', async () => {
+      const expectedRootPath = '/root/dir';
+      jest
+        .spyOn(service, 'git')
+        .mockResolvedValueOnce({ code: 0, stdout: `${expectedRootPath}\n` });
+
+      const actualRootPath = await service.getRepositoryRootPath({
+        directory: '/some/other/dir',
+      });
+
+      expect(actualRootPath).toEqual(expectedRootPath);
+      expect(service.git).toHaveBeenCalledExactlyOnceWith(
+        'rev-parse',
+        ['--show-toplevel'],
+        expect.objectContaining({ workingDirectory: '/some/other/dir' }),
+      );
+    });
+  });
+
   describe('diff', () => {
     it('should call git diff', async () => {
       const expectedResult: SpawnedProcessResult = { code: 0, stdout: '' };

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -10,10 +10,10 @@ import {
  */
 type GitDiffOptions = {
   /**
-   * The commit to compare to. This can also accept several commits.
+   * The commits to compare.
    * See https://git-scm.com/docs/git-diff for more information.
    */
-  commit?: string;
+  commits?: string[];
 
   /**
    * Lists the staged changes.
@@ -91,7 +91,7 @@ export class GitService {
   async diff(
     options: GitDiffOptions & SpawnOptions = {},
   ): Promise<SpawnedProcessResult> {
-    const { cached, commit, nameOnly, paths, ...spawnOptions } = options;
+    const { cached, commits, nameOnly, paths, ...spawnOptions } = options;
 
     const args: string[] = [];
     if (cached) {
@@ -101,8 +101,8 @@ export class GitService {
       args.push('--name-only');
     }
     // This should be placed after all other options...
-    if (commit) {
-      args.push(commit);
+    if (commits) {
+      args.push(...commits);
     }
     // Except paths, placed after a separator.
     if (paths && paths.length > 0) {

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -59,6 +59,30 @@ export class GitService {
   }
 
   /**
+   * Gets the root path of the Git repository.
+   * Defaults to searching from the current working directory.
+   *
+   * @param options Options for the operation.
+   * @returns The root path of the Git repository.
+   */
+  async getRepositoryRootPath(
+    options: {
+      /**
+       * The directory to search from, assumed to be part of a repository.
+       */
+      directory?: string;
+    } = {},
+  ): Promise<string> {
+    const result = await this.git('rev-parse', ['--show-toplevel'], {
+      workingDirectory: options.directory,
+      capture: { stdout: true },
+      logging: null,
+    });
+
+    return result.stdout?.trim() ?? '';
+  }
+
+  /**
    * Runs `git diff` with the given options.
    *
    * @param options Options for the diff.


### PR DESCRIPTION
This adds the self-explanatory `getRepositoryRootPath` method, and renames the `commit` option to `commits`, to handle list of commits explicitly.

### Commits

- **✨ Implement GitService.getRepositoryRootPath**
- **💥 Change GitService.diff option to commits**
- **📝 Update changelog**