### PR TITLE
`cs diff` command to get projects with changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking change:
 Features:
 
 - Implement `GitService.getRepositoryRootPath`.
+- Define `ProjectDiff` and implement it for any projects and workspace.
 
 ## v0.21.0 (2024-05-27)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The core module defines and implements many base `cs` commands. As a Causa user,
 - `cs infrastructure`: Provides the `prepare` and `deploy` commands. Those commands run "infrastructure processors" before the actual infrastructure operation, and tear those down afterwards. The core module does not implement actual infrastructure operations, which depend on the project's language, e.g. `terraform`.
 - `cs publish`: While many base commands (e.g. `cs build`) are straightforward and should be implemented by the modules handling the corresponding project types and languages, `cs publish` provides some logic around these base commands to both build and push a project's artefact. The artefact is tagged according to the passed value or format, e.g. `my-custom-tag` or `semantic`. (The latter will use the project's version as the tag.)
 - `cs openapi generateSpecification`: Provides the implementation at the workspace level, which triggers the generation of the specification in each project, and merges together the outputs. Does not provide any project type-specific implementation.
+- `cs diff`: Lists changed projects based on the output of `git diff`. This can be useful for CI workflows. This module entirely implements the logic, and no other module is expected to provide an implementation.
 
 ### Secrets backend
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.7.7",
         "class-validator": "^0.14.1",
         "js-yaml": "^4.1.0",
+        "micromatch": "^4.0.8",
         "openapi-merge": "^1.3.3",
         "pino": "^9.4.0",
         "quicktype-core": "^23.0.170"
@@ -24,6 +25,7 @@
         "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.13",
         "@types/js-yaml": "^4.0.9",
+        "@types/micromatch": "^4.0.9",
         "@types/node": "^18.19.54",
         "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
@@ -1993,6 +1995,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.4.tgz",
+      "integrity": "sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2067,6 +2076,16 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.9.tgz",
+      "integrity": "sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "18.19.54",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "axios": "^1.7.7",
     "class-validator": "^0.14.1",
     "js-yaml": "^4.1.0",
+    "micromatch": "^4.0.8",
     "openapi-merge": "^1.3.3",
     "pino": "^9.4.0",
     "quicktype-core": "^23.0.170"
@@ -43,6 +44,7 @@
     "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.13",
     "@types/js-yaml": "^4.0.9",
+    "@types/micromatch": "^4.0.9",
     "@types/node": "^18.19.54",
     "eslint": "^9.12.0",
     "eslint-config-prettier": "^9.1.0",

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -24,6 +24,7 @@ import {
 import { OpenApiGenerateSpecificationForWorkspace } from './openapi/index.js';
 import {
   ProjectDependenciesUpdateAndTestForAll,
+  ProjectDiffForAll,
   ProjectInitForWorkspace,
   ProjectPublishArtefactForAll,
   ProjectPushArtefactForServiceContainer,
@@ -49,6 +50,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
     InfrastructureProcessAndPrepareForAll,
     OpenApiGenerateSpecificationForWorkspace,
     ProjectDependenciesUpdateAndTestForAll,
+    ProjectDiffForAll,
     ProjectInitForWorkspace,
     ProjectPublishArtefactForAll,
     ProjectPushArtefactForServiceContainer,

--- a/src/functions/project/diff.spec.ts
+++ b/src/functions/project/diff.spec.ts
@@ -1,0 +1,128 @@
+import type { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import { join } from 'path';
+import { ProjectDiff } from '../../definitions/index.js';
+import { GitService } from '../../services/index.js';
+import { ProjectDiffForAll } from './diff.js';
+
+describe('ProjectDiffForAll', () => {
+  const gitRoot = '/git';
+  const workspaceRoot = '/git/workspace';
+  let context: WorkspaceContext;
+  let gitService: GitService;
+
+  beforeEach(() => {
+    ({ context } = createContext({
+      rootPath: workspaceRoot,
+      functions: [ProjectDiffForAll],
+    }));
+    jest.spyOn(context, 'clone').mockImplementation(async (options) => {
+      const workingDirectory = options?.workingDirectory ?? '❌';
+      const { context } = createContext({
+        rootPath: workspaceRoot,
+        workingDirectory,
+        projectPath: workingDirectory,
+        configuration: {
+          project: {
+            name: workingDirectory,
+            type: '🤖',
+            language: '🤖',
+            ...(options?.workingDirectory?.includes('proj2')
+              ? { externalFiles: ['other/*.txt'] }
+              : {}),
+          },
+        },
+      });
+      return context;
+    });
+    jest
+      .spyOn(context, 'listProjectPaths')
+      .mockResolvedValue([
+        join(workspaceRoot, 'proj1'),
+        join(workspaceRoot, 'proj2'),
+        join(workspaceRoot, 'proj3'),
+      ]);
+
+    gitService = context.service(GitService);
+    jest.spyOn(gitService, 'getRepositoryRootPath').mockResolvedValue(gitRoot);
+  });
+
+  function mockFilesDiff(files: string[]) {
+    jest
+      .spyOn(gitService, 'filesDiff')
+      .mockResolvedValueOnce(files.map((f) => join('workspace', f)));
+  }
+
+  it('should throw if too many commits are provided', async () => {
+    const actualPromise = context.call(ProjectDiff, {
+      commits: ['a', 'b', 'c'],
+    });
+
+    await expect(actualPromise).rejects.toThrow(/too many commits/i);
+  });
+
+  it('should only return changed projects', async () => {
+    mockFilesDiff([
+      'proj1/file1',
+      'proj1/file2',
+      'proj3/sub/file3',
+      'other/nope.nope',
+    ]);
+
+    const actualResult = await context.call(ProjectDiff, {});
+
+    expect(actualResult).toEqual({
+      [join(workspaceRoot, 'proj1')]: {
+        diff: expect.toContainAllValues([
+          join(workspaceRoot, 'proj1/file1'),
+          join(workspaceRoot, 'proj1/file2'),
+        ]),
+        configuration: expect.objectContaining({
+          name: join(workspaceRoot, 'proj1'),
+        }),
+      },
+      [join(workspaceRoot, 'proj3')]: {
+        diff: [join(workspaceRoot, 'proj3/sub/file3')],
+        configuration: expect.objectContaining({
+          name: join(workspaceRoot, 'proj3'),
+        }),
+      },
+    });
+    expect(gitService.filesDiff).toHaveBeenCalledExactlyOnceWith({
+      commits: [],
+    });
+  });
+
+  it('should return a project changed by its external files', async () => {
+    mockFilesDiff(['other/file1.txt']);
+
+    const actualResult = await context.call(ProjectDiff, {});
+
+    expect(actualResult).toEqual({
+      [join(workspaceRoot, 'proj2')]: {
+        diff: [join(workspaceRoot, 'other/file1.txt')],
+        configuration: expect.objectContaining({
+          name: join(workspaceRoot, 'proj2'),
+        }),
+      },
+    });
+    expect(gitService.filesDiff).toHaveBeenCalledExactlyOnceWith({
+      commits: [],
+    });
+  });
+
+  it('should use the provided commits', async () => {
+    mockFilesDiff([]);
+
+    const actualResult = await context.call(ProjectDiff, {
+      commits: ['a', 'b'],
+    });
+
+    expect(actualResult).toEqual({});
+    expect(gitService.filesDiff).toHaveBeenCalledExactlyOnceWith({
+      commits: ['a', 'b'],
+    });
+  });
+});

--- a/src/functions/project/diff.ts
+++ b/src/functions/project/diff.ts
@@ -1,0 +1,96 @@
+import { WorkspaceContext } from '@causa/workspace';
+import micromatch from 'micromatch';
+import { join } from 'path';
+import {
+  ProjectDiff,
+  type ProjectDiffResult,
+} from '../../definitions/index.js';
+import { GitService } from '../../services/index.js';
+
+/**
+ * Implements {@link ProjectDiff} for all projects and the workspace itself.
+ * This function only makes sense at the workspace level, as it lists projects.
+ * However there's nothing wrong with running it from within a project.
+ */
+export class ProjectDiffForAll extends ProjectDiff {
+  /**
+   * Checks a project within the workspace for changes.
+   * Changes are detected if files under the project path have changed, or if any of the files listed in the project's
+   * `project.externalFiles` configuration has changed.
+   *
+   * @param projectPath The path to the project to check for changes.
+   * @param context The {@link WorkspaceContext}.
+   * @param filesDiff The files that have changed in the repository, according to Git.
+   * @returns The diff result for the project, or `null` if no changes were found.
+   */
+  private async checkDiffForProjectPath(
+    projectPath: string,
+    context: WorkspaceContext,
+    filesDiff: string[],
+  ): Promise<ProjectDiffResult[string] | null> {
+    const projectContext = await context.clone({
+      workingDirectory: projectPath,
+      processors: null,
+    });
+
+    const patterns = projectContext.get('project.externalFiles') ?? [];
+    const globs = [
+      join(projectPath, '**', '*'),
+      ...patterns.map((d) => join(context.rootPath, d)),
+    ];
+
+    const diff = micromatch(filesDiff, globs);
+    if (diff.length === 0) {
+      context.logger.debug(`No change found in project '${projectPath}'.`);
+      return null;
+    }
+
+    context.logger.debug(
+      `Changes found in project '${projectPath}', generating project configuration.`,
+    );
+    const configuration = await projectContext.getAndRender('project');
+    return { diff, configuration };
+  }
+
+  async _call(context: WorkspaceContext): Promise<ProjectDiffResult> {
+    const commits = this.commits ?? [];
+    if (commits.length > 2) {
+      throw new Error(
+        `Too many commits provided. At most two commits can be compared.`,
+      );
+    }
+
+    context.logger.info('🔍 Checking for changes in projects.');
+
+    const gitService = context.service(GitService);
+
+    const [projectPaths, repoRoot, filesDiff] = await Promise.all([
+      context.listProjectPaths(),
+      gitService.getRepositoryRootPath(),
+      gitService.filesDiff({ commits }),
+    ]);
+    const absoluteFilesDiff = filesDiff.map((f) => join(repoRoot, f));
+
+    context.logger.debug(
+      `Git diff returned files: ${filesDiff.map((f) => `'${f}'`).join(', ')}.`,
+    );
+    context.logger.debug(
+      `Checking ${projectPaths.length} projects for changes.`,
+    );
+
+    const changedProjectsEntries = await Promise.all(
+      projectPaths.map(async (p) => [
+        p,
+        await this.checkDiffForProjectPath(p, context, absoluteFilesDiff),
+      ]),
+    );
+
+    return Object.fromEntries(
+      changedProjectsEntries.filter(([, diff]) => diff != null),
+    );
+  }
+
+  _supports(): boolean {
+    return true;
+  }
+}

--- a/src/functions/project/index.ts
+++ b/src/functions/project/index.ts
@@ -1,4 +1,5 @@
 export { ProjectDependenciesUpdateAndTestForAll } from './dependencies-update-and-test.js';
+export { ProjectDiffForAll } from './diff.js';
 export { ProjectInitForWorkspace } from './init-workspace.js';
 export { ProjectPublishArtefactForAll } from './publish-artefact.js';
 export { ProjectPushArtefactForServiceContainer } from './push-artefact-service-container.js';


### PR DESCRIPTION
This PR defines and implements the `ProjectDiff` workspace function and CLI command, which looks at Git changes to find changed projects.
A programmatic call to the function returns a detailed changes list (dictionary) with information about each project (the list of changed files and the project configuration). A call to the CLI returns the list of projects (paths), or the detailed changes when using the `--json` option.

### Commits

- **➕ Depend on micromatch**
- **✨ Define the ProjectDiff workspace function and command**
- **✨ Implement ProjectDiff for all projects and workspace**
- **📝 Update changelog**
- **📝 Document the cs diff command**