### PR TITLE
🔖 Prepare v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.22.1 (2024-10-09)
+
+Fixes:
+
+- Fix `outputFn` in commands that would log the arguments to the output.
+
 ## v0.22.0 (2024-10-07)
 
 Breaking change:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.6.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Fix `outputFn` in commands that would log the arguments to the output.

### Commits

- **🔖 Set version to 0.22.1**
- **📝 Update changelog**