### PR TITLE
🔖 Prepare v0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.22.3 (2025-05-12)
+
 Chore:
 
 - Adapt to `quicktype` breaking changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.6.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": "github:causa-io/workspace-module-core",
   "license": "ISC",


### PR DESCRIPTION
Chore:

- Adapt to `quicktype` breaking changes.

### Commits

- **🔖 Set version to 0.22.3**
- **📝 Update changelog**