### PR TITLE
🐛 Fix JSONSchema references during code generation

### DIFF
--- a/src/code-generation/generate-schema.spec.ts
+++ b/src/code-generation/generate-schema.spec.ts
@@ -176,7 +176,7 @@ describe('generateCodeForSchemas', () => {
         constProperties: [],
         objectAttributes: {},
         propertiesAttributes: {},
-        uri: `${referencedPath}#`,
+        uri: referencedPath,
       },
       NestedTypeInReferenced: {
         uri: `${referencedPath}#/myCustomSchemas/NestedTypeInReferenced`,

--- a/src/code-generation/jsonschema-attribute-producer.ts
+++ b/src/code-generation/jsonschema-attribute-producer.ts
@@ -1,5 +1,25 @@
-import type { JSONSchemaAttributeProducer } from 'quicktype-core/dist/input/JSONSchemaInput.js';
+import type {
+  JSONSchemaAttributeProducer,
+  Ref,
+} from 'quicktype-core/dist/input/JSONSchemaInput.js';
 import { causaTypeAttributeKind } from './causa-attribute-kind.js';
+
+/**
+ * Normalizes a JSONSchema URI.
+ * Trailing empty fragments are removed, and the fragment is ensured to start with a `/`.
+ *
+ * @param ref The {@link Ref} to normalize.
+ * @returns The normalized URI string.
+ */
+function normalizeUri(ref: Ref): string {
+  const pathAndFragment = ref.toString().split('#', 2);
+  if (!pathAndFragment[1]) {
+    return pathAndFragment[0];
+  }
+
+  const fragmentHasSlash = pathAndFragment[1].startsWith('/');
+  return pathAndFragment.join(fragmentHasSlash ? '#' : '#/');
+}
 
 /**
  * A {@link JSONSchemaAttributeProducer} that parses the input JSON schema for the `causa` attribute.
@@ -18,7 +38,7 @@ export const causaJsonSchemaAttributeProducer: JSONSchemaAttributeProducer = (
     return undefined;
   }
 
-  const uri = ref.toString();
+  const uri = normalizeUri(ref);
   const objectAttributes: Record<string, string> =
     'causa' in schema && typeof schema.causa === 'object' ? schema.causa : {};
   const propertiesAttributes: Record<string, Record<string, string>> = {};

--- a/src/code-generation/schema-store.spec.ts
+++ b/src/code-generation/schema-store.spec.ts
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+import { FetchingJSONSchemaStore } from 'quicktype-core';
+import { AbsoluteIdJsonSchemaStore } from './schema-store.js';
+
+describe('AbsoluteIdJsonSchemaStore', () => {
+  let store: AbsoluteIdJsonSchemaStore;
+  let mockSuperFetch: jest.SpiedFunction<FetchingJSONSchemaStore['fetch']>;
+
+  beforeEach(() => {
+    store = new AbsoluteIdJsonSchemaStore();
+    mockSuperFetch = jest.spyOn(FetchingJSONSchemaStore.prototype, 'fetch');
+  });
+
+  describe('fetch', () => {
+    it('should return undefined for relative paths', async () => {
+      const relativePaths = [
+        'relative/path/schema.json',
+        './relative/path/schema.json',
+        '../relative/path/schema.json',
+        'schema.json',
+      ];
+
+      for (const path of relativePaths) {
+        const result = await store.fetch(path);
+        expect(result).toBeUndefined();
+      }
+      expect(mockSuperFetch).not.toHaveBeenCalled();
+    });
+
+    it('should handle absolute paths and set $id', async () => {
+      const absolutePath = '/absolute/path/to/schema.json';
+      const mockSchema = { type: 'object', properties: {} };
+      mockSuperFetch.mockResolvedValue(mockSchema);
+
+      const result = await store.fetch(absolutePath);
+
+      expect(mockSuperFetch).toHaveBeenCalledExactlyOnceWith(absolutePath);
+      const expectedSchema = { ...mockSchema, $id: absolutePath };
+      expect(result).toEqual(expectedSchema);
+      expect(store.absolutePathSchemas[absolutePath]).toEqual(expectedSchema);
+    });
+
+    it('should return undefined when super.fetch returns undefined for absolute paths', async () => {
+      const absolutePath = '/absolute/path/to/schema.json';
+      mockSuperFetch.mockResolvedValue(undefined);
+
+      const result = await store.fetch(absolutePath);
+
+      expect(mockSuperFetch).toHaveBeenCalledExactlyOnceWith(absolutePath);
+      expect(result).toBeUndefined();
+      expect(store.absolutePathSchemas[absolutePath]).toBeUndefined();
+    });
+
+    it('should handle non-object schemas for absolute paths', async () => {
+      const absolutePath = '/absolute/path/to/schema.json';
+      const booleanSchema = true;
+      mockSuperFetch.mockResolvedValue(booleanSchema);
+
+      const result = await store.fetch(absolutePath);
+
+      expect(mockSuperFetch).toHaveBeenCalledExactlyOnceWith(absolutePath);
+      expect(result).toBe(booleanSchema);
+      expect(store.absolutePathSchemas[absolutePath]).toBe(booleanSchema);
+    });
+
+    it('should pass regular URLs directly to super.fetch', async () => {
+      const urls = [
+        'http://example.com/schema.json',
+        'https://example.com/schema.json',
+        'ftp://example.com/schema.json',
+      ];
+      const mockSchema = { type: 'string' };
+      mockSuperFetch.mockResolvedValue(mockSchema);
+
+      for (const url of urls) {
+        const result = await store.fetch(url);
+
+        expect(mockSuperFetch).toHaveBeenCalledWith(url);
+        expect(result).toEqual(mockSchema);
+        expect(store.absolutePathSchemas[url]).toBeUndefined();
+      }
+      expect(mockSuperFetch).toHaveBeenCalledTimes(urls.length);
+    });
+  });
+});

--- a/src/code-generation/schema-store.ts
+++ b/src/code-generation/schema-store.ts
@@ -1,0 +1,37 @@
+import { FetchingJSONSchemaStore, type JSONSchema } from 'quicktype-core';
+
+/**
+ * A JSONSchema store that does not resolve relative URIs, to force the use of absolute paths.
+ * Each local schema is stored in {@link AbsoluteIdJsonSchemaStore.absolutePathSchemas}, and the `$id` field of the
+ * schema is set to its absolute path to ease reference resolution.
+ */
+export class AbsoluteIdJsonSchemaStore extends FetchingJSONSchemaStore {
+  /**
+   * A map of absolute paths to (local) JSON schemas.
+   */
+  readonly absolutePathSchemas: Record<string, JSONSchema> = {};
+
+  async fetch(address: string): Promise<JSONSchema | undefined> {
+    try {
+      // The base implementation is used for a valid URL with a scheme.
+      new URL(address);
+      return super.fetch(address);
+    } catch {}
+
+    const isAbsolute = address.startsWith('/');
+    if (!isAbsolute) {
+      return undefined;
+    }
+
+    const schema = await super.fetch(address);
+
+    if (schema) {
+      if (typeof schema === 'object') {
+        schema.$id = address;
+      }
+      this.absolutePathSchemas[address] = schema;
+    }
+
+    return schema;
+  }
+}


### PR DESCRIPTION
### 📝 Description of the PR

This fixes issues with resolution of JSONSchema file paths and the use of `$ref`.
The changelog is not updated as there hasn't been a release since the new features were introduced.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.