### PR TITLE
✨ Always pull emulator Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Add `pull` option to `DockerService.run()` method supporting `'always'`, `'missing'`, and `'never'` values.
+- Update `DockerEmulatorService` to use `pull: 'always'` by default for emulator containers.
+
 ## v0.23.0 (2025-08-05)
 
 Breaking changes:

--- a/src/services/docker-emulator.spec.ts
+++ b/src/services/docker-emulator.spec.ts
@@ -45,6 +45,7 @@ describe('DockerEmulatorService', () => {
         'my-image',
         expect.objectContaining({
           detach: true,
+          pull: 'always',
           name: 'my-container',
           network: 'my-network',
           publish: [{ local: 8080, container: 1234 }],

--- a/src/services/docker-emulator.ts
+++ b/src/services/docker-emulator.ts
@@ -51,6 +51,7 @@ export class DockerEmulatorService {
     await this.dockerService.run(dockerImage, {
       detach: true,
       logging: { stdout: null, stderr: 'debug' },
+      pull: 'always',
       ...options,
       name: containerName,
       network,

--- a/src/services/docker.spec.ts
+++ b/src/services/docker.spec.ts
@@ -224,6 +224,7 @@ describe('DockerService', () => {
         envFile: '/some/file',
         rm: true,
         network: 'someNetwork',
+        pull: 'always',
       });
 
       expect(service.docker).toHaveBeenCalledOnce();
@@ -245,6 +246,7 @@ describe('DockerService', () => {
       expect(actualArgs).toContain('--rm');
       expect(actualArgs).toContain('--network someNetwork');
       expect(actualArgs).toContain('--env-file /some/file');
+      expect(actualArgs).toContain('--pull always');
     });
   });
 

--- a/src/services/docker.ts
+++ b/src/services/docker.ts
@@ -351,6 +351,11 @@ export class DockerService {
        * The network in which the container should be run.
        */
       network?: string;
+
+      /**
+       * Pull image policy. Defaults to `missing`.
+       */
+      pull?: 'always' | 'missing' | 'never';
     } & SpawnOptions = {},
   ): Promise<SpawnedProcessResult> {
     const {
@@ -364,6 +369,7 @@ export class DockerService {
       detach,
       publish,
       network,
+      pull,
       ...spawnOptions
     } = options;
     const args = [image, ...(commandAndArgs ?? [])];
@@ -421,6 +427,10 @@ export class DockerService {
       }
       args.splice(0, 0, '--publish', arg);
     });
+
+    if (pull) {
+      args.splice(0, 0, '--pull', pull);
+    }
 
     return await this.docker('run', args, spawnOptions);
   }


### PR DESCRIPTION
### 📝 Description of the PR

This PR adds support for Docker's `--pull` option to the `DockerService.run()` method and updates the `DockerEmulatorService` to always pull the latest images.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.