### PR TITLE
💥 Default to the workspace or project directory when writing OpenAPI specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Default to the workspace or project directory when writing OpenAPI specs.
+
 ## v0.31.0 (2026-04-20)
 
 Features:

--- a/src/functions/openapi/generate-specification-project.call.ts
+++ b/src/functions/openapi/generate-specification-project.call.ts
@@ -4,7 +4,7 @@ import type { OpenAPIV3_1 } from '@scalar/openapi-types';
 import { readFile, writeFile } from 'fs/promises';
 import { globby } from 'globby';
 import { dump, load } from 'js-yaml';
-import { dirname, isAbsolute, relative, resolve } from 'path';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import type { OpenApiConfiguration } from '../../configurations/index.js';
 import type { OpenApiGenerateSpecificationForProjectByMerging } from './generate-specification-project.js';
 import { rewriteRefs } from './utils.js';
@@ -52,7 +52,9 @@ export default async function call(
     openApiConf.get('openApi.global') ?? {};
   const projectPath = context.getProjectPathOrThrow();
 
-  const output = resolve(this.output ?? DEFAULT_OPENAPI_OUTPUT);
+  const output = this.output
+    ? resolve(this.output)
+    : join(projectPath, DEFAULT_OPENAPI_OUTPUT);
   const outputDir = dirname(output);
 
   context.logger.info(`📝 Resolving OpenAPI specification globs for project.`);

--- a/src/functions/openapi/generate-specification-workspace.call.ts
+++ b/src/functions/openapi/generate-specification-workspace.call.ts
@@ -6,7 +6,7 @@ import { join as joinSpecs } from '@scalar/openapi-parser';
 import type { OpenAPIV3_1 } from '@scalar/openapi-types';
 import { writeFile } from 'fs/promises';
 import { dump, load } from 'js-yaml';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 import { isDeepStrictEqual } from 'util';
 import type { OpenApiConfiguration } from '../../configurations/index.js';
 import { OpenApiGenerateSpecification } from '../../definitions/index.js';
@@ -204,7 +204,9 @@ export default async function call(
   this: OpenApiGenerateSpecificationForWorkspace,
   context: WorkspaceContext,
 ): Promise<string> {
-  const output = resolve(this.output ?? DEFAULT_OPENAPI_OUTPUT);
+  const output = this.output
+    ? resolve(this.output)
+    : join(context.rootPath, DEFAULT_OPENAPI_OUTPUT);
   const projectPaths = await context.listProjectPaths();
 
   const openApiSpecifications = await Promise.all(


### PR DESCRIPTION
### 📝 Description of the PR

The previous default was the current directory. However using the workspace or project directory is what is being used as the default for other workspace functions, and it makes results more consistent.
It also eases the usage of those functions by the VSCode extension, which has a read-only current directory.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.