### PR TITLE
🔖 Prepare v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.32.0 (2026-04-21)
+
 Breaking changes:
 
 - Default to the workspace or project directory when writing OpenAPI specs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.7.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Default to the workspace or project directory when writing OpenAPI specs.
- Default the `events backfill` output file to the workspace root instead of the current working directory.
- Support a new project-scoped trigger format `<projectPath>#<triggerName>[?<options>]` in `events backfill`. When a trigger matches, the workspace context is cloned for the referenced project and `EventTopicBrokerCreateTrigger` is called with a structured `{ name, options }` payload.
- Replace the `BackfillEventsSource` / `BackfillEventPublisher` / `JsonFilesEventSource` abstractions with an async-iterable-based contract. Introduce the `EventTopicCreateBackfillSource` workspace function (with a `json://<glob>` implementation) to build the `AsyncIterable<BackfillEvent>` consumed by `EventTopicBrokerPublishEvents`. Remove the `./backfill` package subpath export.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~