### PR TITLE
✨ `MakeHttpRequest` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
 
 - Implement `ScenarioRun` for any context.
+- Add the `MakeHttpRequest` workspace function.
 
 ## v0.32.0 (2026-04-21)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This section provides pointers for Causa module developers. Workspace function d
 - [Project](./src/definitions/project.ts): Many of the definitions in this file should be implemented by modules providing support for a language and/or project type, e.g. `ProjectBuildArtefact`, `ProjectReadVersion`, `ProjectPushArtefact`, `ProjectGetArtefactDestination`.
 - [OpenAPI](./src/definitions/openapi.ts): Functions related to OpenAPI specifications. `OpenApiGenerateSpecification` should be implemented by Causa modules providing support for a language / project type (if relevant).
 - [Scenario](./src/definitions/scenario.ts): The `ScenarioRun` definition powering `cs scenario run`. The implementation is generic and shipped by this module — it dispatches to other workspace functions, so other modules only need to expose the functions referenced from scenario steps.
+- [HTTP](./src/definitions/http.ts): The `MakeHttpRequest` function, useful as a scenario step (e.g. for end-to-end checks against a deployed service).
 
 ## 🔨 Services
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "jest": "^30.3.0",
         "jest-extended": "^7.0.0",
+        "nock": "^14.0.10",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1"
@@ -1384,6 +1385,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.7.tgz",
+      "integrity": "sha512-D0nkS5+sx87mYpxFqASImCineYoEl9wGlUPrzkuS0ohzG8wfophLpE+I76qGJ0slLAVI19do5SI9pWJNCVf4fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1431,6 +1450,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -4511,6 +4555,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5386,6 +5437,13 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5674,6 +5732,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.13.tgz",
+      "integrity": "sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.41.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5782,6 +5855,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -6207,6 +6287,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -6662,6 +6752,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "jest": "^30.3.0",
     "jest-extended": "^7.0.0",
+    "nock": "^14.0.10",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1"

--- a/src/definitions/http.ts
+++ b/src/definitions/http.ts
@@ -1,0 +1,64 @@
+import { WorkspaceFunction } from '@causa/workspace';
+import { AllowMissing } from '@causa/workspace/validation';
+import { IsObject, IsString } from 'class-validator';
+
+/**
+ * The result of a {@link MakeHttpRequest} call.
+ */
+export type HttpResponse = {
+  /**
+   * The HTTP status code of the response.
+   */
+  readonly statusCode: number;
+
+  /**
+   * The response headers, with header names lowercased.
+   */
+  readonly headers: Record<string, string>;
+
+  /**
+   * The parsed response body. JSON responses are parsed, other content types are returned as a string.
+   */
+  readonly body: any;
+};
+
+/**
+ * Performs an HTTP request and returns the status code, headers, and parsed body.
+ */
+export abstract class MakeHttpRequest extends WorkspaceFunction<
+  Promise<HttpResponse>
+> {
+  /**
+   * The base URL of the target service. May include a path prefix (e.g. `https://api.example.com/v1`). The scheme is
+   * optional and defaults to `https://` when missing.
+   */
+  @IsString()
+  readonly baseUrl!: string;
+
+  /**
+   * The HTTP method to use. Defaults to `GET`.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly method?: string;
+
+  /**
+   * The path appended to {@link MakeHttpRequest.baseUrl}. Defaults to `/`.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly path?: string;
+
+  /**
+   * Additional request headers, keyed by header name.
+   */
+  @AllowMissing()
+  @IsObject()
+  readonly headers?: Record<string, string>;
+
+  /**
+   * The request body. Objects and arrays are JSON-serialized, strings are sent as-is.
+   */
+  @AllowMissing()
+  readonly body?: any;
+}

--- a/src/definitions/index.ts
+++ b/src/definitions/index.ts
@@ -2,6 +2,7 @@ export * from './causa.js';
 export * from './emulator.js';
 export * from './environment.js';
 export * from './event-topic.js';
+export * from './http.js';
 export * from './infrastructure.js';
 export * from './model.js';
 export * from './openapi.js';

--- a/src/functions/http/index.ts
+++ b/src/functions/http/index.ts
@@ -1,0 +1,1 @@
+export { MakeHttpRequestForAll } from './make-request.js';

--- a/src/functions/http/make-request.spec.ts
+++ b/src/functions/http/make-request.spec.ts
@@ -1,0 +1,125 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import 'jest-extended';
+import nock from 'nock';
+import { MakeHttpRequest } from '../../definitions/index.js';
+import { MakeHttpRequestForAll } from './make-request.js';
+
+describe('MakeHttpRequestForAll', () => {
+  let context: WorkspaceContext;
+
+  beforeEach(() => {
+    ({ context } = createContext({ functions: [MakeHttpRequestForAll] }));
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should default to GET / and parse a JSON response', async () => {
+    const scope = nock('https://api.example.com')
+      .get('/')
+      .reply(200, { hello: 'world' }, { 'content-type': 'application/json' });
+
+    const actual = await context.call(MakeHttpRequest, {
+      baseUrl: 'https://api.example.com',
+    });
+
+    expect(actual).toEqual({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: { hello: 'world' },
+    });
+    scope.done();
+  });
+
+  it('should send a JSON body with content-type and forward custom headers', async () => {
+    const scope = nock('https://api.example.com', {
+      reqheaders: {
+        'content-type': 'application/json',
+        authorization: 'Bearer token',
+      },
+    })
+      .post('/items', { name: 'thing' })
+      .reply(201, { id: '🆔' }, { 'content-type': 'application/json' });
+
+    const actual = await context.call(MakeHttpRequest, {
+      baseUrl: 'https://api.example.com',
+      method: 'POST',
+      path: '/items',
+      headers: { authorization: 'Bearer token' },
+      body: { name: 'thing' },
+    });
+
+    expect(actual).toEqual({
+      statusCode: 201,
+      headers: { 'content-type': 'application/json' },
+      body: { id: '🆔' },
+    });
+    scope.done();
+  });
+
+  it('should send a string body as-is and return non-JSON responses as text', async () => {
+    const scope = nock('https://api.example.com')
+      .put('/raw', 'plain-text')
+      .matchHeader(
+        'content-type',
+        (value) => value === undefined || !value.includes('application/json'),
+      )
+      .reply(200, 'hello there', { 'content-type': 'text/plain' });
+
+    const actual = await context.call(MakeHttpRequest, {
+      baseUrl: 'https://api.example.com',
+      method: 'PUT',
+      path: '/raw',
+      body: 'plain-text',
+    });
+
+    expect(actual).toEqual({
+      statusCode: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: 'hello there',
+    });
+    scope.done();
+  });
+
+  it('should default the scheme to https when missing and honor a path prefix', async () => {
+    const scope = nock('https://api.example.com')
+      .get('/v1/items/42')
+      .reply(200, { id: 42 }, { 'content-type': 'application/json' });
+
+    const actual = await context.call(MakeHttpRequest, {
+      baseUrl: 'api.example.com/v1/',
+      path: 'items/42',
+    });
+
+    expect(actual).toEqual({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: { id: 42 },
+    });
+    scope.done();
+  });
+
+  it('should expose error responses without throwing', async () => {
+    const scope = nock('https://api.example.com')
+      .get('/missing')
+      .reply(
+        404,
+        { error: 'not found' },
+        { 'content-type': 'application/json' },
+      );
+
+    const actual = await context.call(MakeHttpRequest, {
+      baseUrl: 'https://api.example.com',
+      path: '/missing',
+    });
+
+    expect(actual).toEqual({
+      statusCode: 404,
+      headers: { 'content-type': 'application/json' },
+      body: { error: 'not found' },
+    });
+    scope.done();
+  });
+});

--- a/src/functions/http/make-request.ts
+++ b/src/functions/http/make-request.ts
@@ -1,0 +1,53 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { type HttpResponse, MakeHttpRequest } from '../../definitions/index.js';
+
+/**
+ * Implements {@link MakeHttpRequest} using the native `fetch` API.
+ */
+export class MakeHttpRequestForAll extends MakeHttpRequest {
+  async _call(context: WorkspaceContext): Promise<HttpResponse> {
+    const method = (this.method ?? 'GET').toUpperCase();
+    const path = this.path ?? '/';
+    const baseUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(this.baseUrl)
+      ? this.baseUrl
+      : `https://${this.baseUrl}`;
+    const url = new URL(path, baseUrl).toString();
+
+    const headers = { ...this.headers };
+    let body: string | undefined;
+    if (this.body !== undefined && method !== 'GET' && method !== 'HEAD') {
+      if (typeof this.body === 'string') {
+        body = this.body;
+      } else {
+        body = JSON.stringify(this.body);
+        if (
+          !Object.keys(headers).some((h) => h.toLowerCase() === 'content-type')
+        ) {
+          headers['content-type'] = 'application/json';
+        }
+      }
+    }
+
+    context.logger.debug(`Making HTTP call '${method} ${url}'.`);
+
+    const response = await fetch(url, { method, headers, body });
+
+    const responseHeaders = Object.fromEntries(
+      Array.from(response.headers).map(([k, v]) => [k.toLowerCase(), v]),
+    );
+
+    const isJson =
+      responseHeaders['content-type']?.includes('application/json');
+    const responseBody = isJson ? await response.json() : await response.text();
+
+    return {
+      statusCode: response.status,
+      headers: responseHeaders,
+      body: responseBody,
+    };
+  }
+
+  _supports(): boolean {
+    return true;
+  }
+}

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -20,6 +20,7 @@ import {
   EventTopicListReferencedInProjectForServerlessFunctions,
   EventTopicListReferencedInProjectForServiceContainer,
 } from './event-topic/index.js';
+import { MakeHttpRequestForAll } from './http/index.js';
 import {
   InfrastructureProcessAndDeployForAll,
   InfrastructureProcessAndPrepareForAll,
@@ -61,6 +62,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
     EventTopicListForAll,
     InfrastructureProcessAndDeployForAll,
     InfrastructureProcessAndPrepareForAll,
+    MakeHttpRequestForAll,
     ModelGenerateCodeForAll,
     ModelMakeGeneratorQuicktypeInputDataForJsonSchema,
     ModelParseCodeGeneratorInputsForAll,


### PR DESCRIPTION
### 📝 Description of the PR

Adds a generic `MakeHttpRequest` workspace function. The primary motivation is to give scenarios a built-in way to talk to deployed services — useful for end-to-end checks and other multi-step workflows that already chain workspace functions together — but the function is independent of scenarios and usable from any workspace.

`MakeHttpRequest` performs an HTTP call using the native `fetch` API and returns the status code, headers, and parsed body. It accepts a `baseUrl` (path prefix allowed, scheme optional and defaulting to `https://`), a method, a path, headers, and a body. Object/array bodies are JSON-serialized with a default `content-type`; string bodies are sent as-is. JSON responses are parsed; everything else is returned as text. Non-2xx responses are surfaced through the response object rather than thrown, so callers (notably scenario expectations) can assert on them.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.