### PR TITLE
✨ Query functions definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 - Implement `ScenarioRun` for any context.
 - Add the `MakeHttpRequest` workspace function.
+- Define the `DatabaseQueryRecords`, `EventTopicQueryEvents`, and `ServiceContainerQueryLogs` workspace functions, to be implemented by other modules.
 
 ## v0.32.0 (2026-04-21)
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,15 @@ This section provides pointers for Causa module developers. Workspace function d
 
 - [Emulators](./src/definitions/emulator.ts): Modules exposing local emulators (e.g. of databases) should implement both `EmulatorStart` and `EmulatorStop` for each of them.
 - [Environment](./src/definitions/environment.ts): Functions mapping to `cs environment` commands. Those are not meant to be implemented by other modules.
-- [Event topic](./src/definitions/event-topic.ts): Functions related to event topics, e.g. backfilling. Modules providing support for a new project type should implement `EventTopicListReferencedInProject`. Modules providing tech stack or cloud provider support should implement the `EventTopicBroker*` functions, and register `EventTopicCreateBackfillSource` implementations for the source schemes they handle (including the "no source" / broker-default case).
+- [Event topic](./src/definitions/event-topic.ts): Functions related to event topics, e.g. backfilling. Modules providing support for a new project type should implement `EventTopicListReferencedInProject`. Modules providing tech stack or cloud provider support should implement the `EventTopicBroker*` functions, register `EventTopicCreateBackfillSource` implementations for the source schemes they handle (including the "no source" / broker-default case), and implement `EventTopicQueryEvents` so events published to a topic can be queried.
 - [Infrastructure](./src/definitions/infrastructure.ts): Modules providing support for an Infrastructure as Code tool (e.g. Terraform, Pulumi) should implement the `InfrastructurePrepare` and `InfrastructureDeploy` functions.
 - [Model](./src/definitions/model.ts): Modules providing support for a programming language can implement new code generators by extending `ModelRunCodeGenerator`.
 - [Project](./src/definitions/project.ts): Many of the definitions in this file should be implemented by modules providing support for a language and/or project type, e.g. `ProjectBuildArtefact`, `ProjectReadVersion`, `ProjectPushArtefact`, `ProjectGetArtefactDestination`.
 - [OpenAPI](./src/definitions/openapi.ts): Functions related to OpenAPI specifications. `OpenApiGenerateSpecification` should be implemented by Causa modules providing support for a language / project type (if relevant).
 - [Scenario](./src/definitions/scenario.ts): The `ScenarioRun` definition powering `cs scenario run`. The implementation is generic and shipped by this module — it dispatches to other workspace functions, so other modules only need to expose the functions referenced from scenario steps.
 - [HTTP](./src/definitions/http.ts): The `MakeHttpRequest` function, useful as a scenario step (e.g. for end-to-end checks against a deployed service).
+- [Database](./src/definitions/database.ts): The `DatabaseQueryRecords` function. Modules providing support for a database engine should register an implementation against their `engine` value.
+- [Service container](./src/definitions/service-container.ts): The `ServiceContainerQueryLogs` function. Modules providing support for a deployment platform should register an implementation that fetches logs for a deployed service container.
 
 ## 🔨 Services
 

--- a/src/definitions/database.ts
+++ b/src/definitions/database.ts
@@ -1,0 +1,30 @@
+import { WorkspaceFunction } from '@causa/workspace';
+import { AllowMissing } from '@causa/workspace/validation';
+import { IsString } from 'class-validator';
+
+/**
+ * Queries a database for records and returns the matching rows or documents.
+ */
+export abstract class DatabaseQueryRecords extends WorkspaceFunction<
+  Promise<any[]>
+> {
+  /**
+   * The database engine to query. Implementations register against a specific engine.
+   */
+  @IsString()
+  readonly engine!: string;
+
+  /**
+   * The name of the database to query within the engine.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly database?: string;
+
+  /**
+   * The query to run against the database.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly query?: string;
+}

--- a/src/definitions/event-topic.ts
+++ b/src/definitions/event-topic.ts
@@ -6,9 +6,13 @@ import {
 } from '@causa/cli';
 import { WorkspaceContext, WorkspaceFunction } from '@causa/workspace';
 import { AllowMissing } from '@causa/workspace/validation';
+import { Transform } from 'class-transformer';
 import {
   IsBoolean,
+  IsDate,
   IsInstance,
+  IsInt,
+  IsPositive,
   IsString,
   Validate,
   type ValidationArguments,
@@ -520,4 +524,73 @@ export abstract class EventTopicBrokerDeleteTopic extends WorkspaceFunction<
    */
   @IsString()
   readonly id!: string;
+}
+
+/**
+ * A single event returned by {@link EventTopicQueryEvents}.
+ */
+export type QueriedEvent = {
+  /**
+   * The time at which the event was published to the topic.
+   */
+  readonly timestamp: Date;
+
+  /**
+   * The event attributes.
+   */
+  readonly attributes: Record<string, string>;
+
+  /**
+   * The event payload.
+   */
+  readonly data: any;
+};
+
+/**
+ * Queries an event topic for events that were published within a time range, optionally restricted by an
+ * implementation-defined `filter`.
+ */
+export abstract class EventTopicQueryEvents extends WorkspaceFunction<
+  Promise<QueriedEvent[]>
+> {
+  /**
+   * The full event topic name to query.
+   */
+  @IsString()
+  readonly topic!: string;
+
+  /**
+   * The inclusive lower bound of the time range over which to look for events.
+   */
+  @AllowMissing()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? new Date(value) : value,
+  )
+  @IsDate()
+  readonly from?: Date;
+
+  /**
+   * The exclusive upper bound of the time range over which to look for events.
+   */
+  @AllowMissing()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? new Date(value) : value,
+  )
+  @IsDate()
+  readonly to?: Date;
+
+  /**
+   * An implementation-specific filter expression.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly filter?: string;
+
+  /**
+   * The maximum number of events to return.
+   */
+  @AllowMissing()
+  @IsInt()
+  @IsPositive()
+  readonly limit?: number;
 }

--- a/src/definitions/index.ts
+++ b/src/definitions/index.ts
@@ -1,4 +1,5 @@
 export * from './causa.js';
+export * from './database.js';
 export * from './emulator.js';
 export * from './environment.js';
 export * from './event-topic.js';

--- a/src/definitions/index.ts
+++ b/src/definitions/index.ts
@@ -8,3 +8,4 @@ export * from './model.js';
 export * from './openapi.js';
 export * from './project.js';
 export * from './scenario.js';
+export * from './service-container.js';

--- a/src/definitions/service-container.ts
+++ b/src/definitions/service-container.ts
@@ -1,0 +1,68 @@
+import { WorkspaceFunction } from '@causa/workspace';
+import { AllowMissing } from '@causa/workspace/validation';
+import { Transform } from 'class-transformer';
+import { IsDate, IsInt, IsPositive, IsString } from 'class-validator';
+
+/**
+ * A single log entry returned by {@link ServiceContainerQueryLogs}.
+ */
+export type QueriedLogEntry = {
+  /**
+   * The time at which the log entry was emitted.
+   */
+  readonly timestamp: Date;
+
+  /**
+   * The payload of the log entry.
+   */
+  readonly message: any;
+};
+
+/**
+ * Queries the log entries emitted by a deployed service container, restricted to a time range and an
+ * implementation-defined `filter`.
+ */
+export abstract class ServiceContainerQueryLogs extends WorkspaceFunction<
+  Promise<QueriedLogEntry[]>
+> {
+  /**
+   * The name of the service container to query logs for.
+   */
+  @IsString()
+  readonly service!: string;
+
+  /**
+   * The inclusive lower bound of the time range over which to look for log entries.
+   */
+  @AllowMissing()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? new Date(value) : value,
+  )
+  @IsDate()
+  readonly from?: Date;
+
+  /**
+   * The exclusive upper bound of the time range over which to look for log entries.
+   */
+  @AllowMissing()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? new Date(value) : value,
+  )
+  @IsDate()
+  readonly to?: Date;
+
+  /**
+   * An implementation-specific filter expression.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly filter?: string;
+
+  /**
+   * The maximum number of log entries to return.
+   */
+  @AllowMissing()
+  @IsInt()
+  @IsPositive()
+  readonly limit?: number;
+}


### PR DESCRIPTION
### 📝 Description of the PR

Adds three new abstract workspace function definitions that other modules are expected to implement: `DatabaseQueryRecords`, `EventTopicQueryEvents`, and `ServiceContainerQueryLogs`. Together they give scenarios (and any other workspace function) a consistent surface for asserting on the state of a deployed system after triggering it — read rows or documents from a database, fetch events that were published to a topic, and pull log entries emitted by a service container.

The three definitions follow a common shape. `EventTopicQueryEvents` and `ServiceContainerQueryLogs` accept an optional time window via `from` and `to` (string-to-`Date` coerced via `@Transform`), an optional implementation-defined `filter` string, and an optional `limit`, and return a typed array of `QueriedEvent` (`timestamp`, `attributes`, `data`) or `QueriedLogEntry` (`timestamp`, `message`) records. `DatabaseQueryRecords` is keyed by `engine` so engine-specific modules can register against their own value (e.g. `google.spanner`, `google.firestore`), and accepts an optional `database` and `query`; the exact query syntax is left to each engine's implementation. None of these are implemented in this module.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.