### PR TITLE
🔖 Prepare v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.34.0 (2026-05-04)
+
 Breaking changes:
 
 - Rename the `MakeHttpRequest` workspace function (and its `MakeHttpRequestForAll` implementation) to `HttpMakeRequest` (and `HttpMakeRequestForAll`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.7.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Rename the `MakeHttpRequest` workspace function (and its `MakeHttpRequestForAll` implementation) to `HttpMakeRequest` (and `HttpMakeRequestForAll`).

Features:

- Add the `query` property to `HttpMakeRequest` to set query string parameters.
- Override the json-e `str` builtin to format `Date` values as ISO strings in scenario templates.
- Add the `after` property to scenario steps to declare explicit step dependencies without using `output()` templates.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~