### PR TITLE
💥 Adapt to `@causa/workspace` breaking changes and remove `BackfillEvent.key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Remove the `key` (ordering) property from `BackfillEvent`.
+
 ## v0.34.0 (2026-05-04)
 
 Breaking changes:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,14 @@
-import tseslint from 'typescript-eslint';
-import { defineConfig } from 'eslint/config';
 import prettier from 'eslint-plugin-prettier/recommended';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
 
 export default defineConfig({
   extends: [...tseslint.configs.recommended, prettier],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { ignoreRestSiblings: true },
+    ],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.34.0",
       "license": "ISC",
       "dependencies": {
-        "@causa/cli": ">= 0.7.0 < 1.0.0",
-        "@causa/workspace": ">= 0.24.1 < 1.0.0",
-        "@scalar/json-magic": "^0.12.11",
-        "@scalar/openapi-parser": "^0.28.1",
+        "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",
+        "@causa/workspace": ">= 0.25.0-beta.2 < 1.0.0",
+        "@scalar/json-magic": "^0.12.12",
+        "@scalar/openapi-parser": "^0.28.2",
         "ajv": "^8.20.0",
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "class-validator": "^0.15.1",
-        "expect": "^30.3.0",
+        "expect": "^30.4.1",
         "globby": "^16.2.0",
         "js-yaml": "^4.1.1",
         "json-e": "^4.8.2",
@@ -32,16 +32,16 @@
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/micromatch": "^4.0.10",
-        "@types/node": "^20.19.39",
+        "@types/node": "^20.19.41",
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
-        "jest": "^30.3.0",
+        "jest": "^30.4.2",
         "jest-extended": "^7.0.0",
-        "nock": "^14.0.14",
+        "nock": "^14.0.15",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.1"
+        "typescript-eslint": "^8.59.3"
       },
       "engines": {
         "node": ">=22"
@@ -562,12 +562,12 @@
       "license": "MIT"
     },
     "node_modules/@causa/cli": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@causa/cli/-/cli-0.7.0.tgz",
-      "integrity": "sha512-9Kf4Vw/2Yn3EZ33BGH7BlEelGak27ix9FFsQ3azNSujjSNQBWjxtO2MJBGT0sWDixcV2++XRDXi7toVSvclmGw==",
+      "version": "0.8.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@causa/cli/-/cli-0.8.0-beta.1.tgz",
+      "integrity": "sha512-6M2kyR4iQKPHhtd7a0ZYb7yAHt5Vp8M0/dHyM1jDh1Hi4nUqBnwBirOQsG9N0X9mY7VO0+VOqlR3+B4faWiliQ==",
       "license": "ISC",
       "dependencies": {
-        "@causa/workspace": ">= 0.23.0 < 1.0.0",
+        "@causa/workspace": ">= 0.25.0-beta.1 < 1.0.0",
         "commander": "^14.0.3",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@causa/workspace": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-0.24.1.tgz",
-      "integrity": "sha512-CBzVZ73so32X5g5X//h3ZwnZjTQeLa4ilHF/ulHuesi+5gJswhpmWzTg51p6f8ooIrLv6fDo3pXzMwc43/uWvw==",
+      "version": "0.25.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-0.25.0-beta.2.tgz",
+      "integrity": "sha512-ZBRsYclZyG0hYqp35FKFEC6h3yNUxVT2kZ637R8tQqY/zxvT0E+Tuurj7iXd0yApd6w6/pKH8YCcr/SAwuQQEQ==",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",
@@ -594,7 +594,7 @@
         "lodash-es": "^4.18.1",
         "pino": "^10.3.1",
         "resolve-package-path": "^4.0.3",
-        "semver": "^7.7.4"
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">=22"
@@ -939,17 +939,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
-      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.3.0",
-        "jest-util": "30.3.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -967,38 +967,39 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
-      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.3.0",
-        "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.3.0",
-        "jest-config": "30.3.0",
-        "jest-haste-map": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.3.0",
-        "jest-resolve-dependencies": "30.3.0",
-        "jest-runner": "30.3.0",
-        "jest-runtime": "30.3.0",
-        "jest-snapshot": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
-        "jest-watcher": "30.3.0",
-        "pretty-format": "30.3.0",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1024,61 +1025,61 @@
       }
     },
     "node_modules/@jest/create-cache-key-function": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.3.0.tgz",
-      "integrity": "sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.4.1.tgz",
+      "integrity": "sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0"
+        "@jest/types": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.3.0"
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.3.0",
-        "jest-snapshot": "30.3.0"
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0"
@@ -1088,18 +1089,18 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
-        "@sinonjs/fake-timers": "^15.0.0",
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1115,46 +1116,46 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
-      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/expect": "30.3.0",
-        "@jest/types": "30.3.0",
-        "jest-mock": "30.3.0"
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-regex-util": "30.0.1"
+        "jest-regex-util": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
-      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -1167,9 +1168,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-worker": "30.3.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1197,9 +1198,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
@@ -1209,13 +1210,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
-      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -1240,14 +1241,14 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
-      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -1256,15 +1257,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
-      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.3.0",
+        "@jest/test-result": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
+        "jest-haste-map": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1282,23 +1283,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
-      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "babel-plugin-istanbul": "^7.0.1",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
         "write-file-atomic": "^5.0.1"
@@ -1318,13 +1319,13 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -1386,9 +1387,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.8",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
-      "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1507,21 +1508,21 @@
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-TqbErkqGijJJW6Ad8lpswHFTmlJaYFt9oolaWF1/Nn9171xdkK9ZDAk3pCaOCWs8WpwvcbUSxIVD8JxdBg0MFg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.6.0.tgz",
+      "integrity": "sha512-pfSamAgBxqFeE8IpEG6uGkHlnPhY1CLeOTttV9+vKQbrBk5b7vvyTsUXv0Hz4kNU1TFrxcTTPE+Akn5S+jlTtQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.12.11",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.11.tgz",
-      "integrity": "sha512-oyICpNyEjBsRHM1DPbS8uyXFnU8fulFhqrMANLTTggSCH1XFNbVs7PMA8HxFLuQzJiQZzpUFf19M/Dx/TpXnpQ==",
+      "version": "0.12.12",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.12.tgz",
+      "integrity": "sha512-F7q6mPlVdHntvEvlJPwzvA2E2fjxsNtMeSzODtcdhp4mdQndMqqxEhy0rKmRvk36Oka+9F/hl3EDG194BpNBGg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.5.5",
+        "@scalar/helpers": "0.6.0",
         "pathe": "^2.0.3",
         "yaml": "^2.8.3"
       },
@@ -1530,13 +1531,13 @@
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.1.tgz",
-      "integrity": "sha512-S6DcqrDBS+wseEw4IqZKL5LEBCbAne851ON7gV5uQUKlciXbYqqBA4peCQalXA/oYF6f0ZA3wMDjhz0GrGoOMw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.2.tgz",
+      "integrity": "sha512-SiOMmCfq6mRCin1hJJjx9gCpPOklPIS57ut2FidBx7NEMNyuUNPRhwVs/5uGL/X0P6m3cd1RKldCauWu4Z8rvw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.5.5",
-        "@scalar/json-magic": "0.12.11",
+        "@scalar/helpers": "0.6.0",
+        "@scalar/json-magic": "0.12.12",
         "@scalar/openapi-types": "0.8.0",
         "@scalar/openapi-upgrader": "0.2.7",
         "ajv": "^8.17.1",
@@ -1600,9 +1601,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1985,9 +1986,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2057,9 +2058,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2093,17 +2094,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2116,7 +2117,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2132,16 +2133,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2157,14 +2158,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2179,14 +2180,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2197,9 +2198,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2214,15 +2215,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2239,9 +2240,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2253,16 +2254,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2281,16 +2282,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2305,13 +2306,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2323,9 +2324,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2657,6 +2658,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2797,27 +2810,28 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.3.0",
+        "@jest/transform": "30.4.1",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.3.0",
+        "babel-preset-jest": "30.4.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -2860,9 +2874,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
-      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2900,13 +2914,13 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
-      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-plugin-jest-hoist": "30.4.0",
         "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
@@ -2947,9 +2961,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2960,9 +2974,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3099,9 +3113,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {
@@ -3382,7 +3396,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3469,9 +3482,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.355",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
+      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3879,17 +3892,17 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.3.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3963,9 +3976,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4418,6 +4431,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4697,16 +4723,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
-      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.3.0"
+        "jest-cli": "30.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -4724,14 +4750,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
-      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.3.0",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -4739,29 +4765,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
-      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/expect": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.3.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-runtime": "30.3.0",
-        "jest-snapshot": "30.3.0",
-        "jest-util": "30.3.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.1",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -4781,21 +4807,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
-      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4814,33 +4840,33 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
-      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.3.0",
-        "@jest/types": "30.3.0",
-        "babel-jest": "30.3.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.3.0",
-        "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.3.0",
-        "jest-runner": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -4875,24 +4901,24 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
+        "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4903,36 +4929,36 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
-      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
-        "jest-util": "30.3.0",
-        "pretty-format": "30.3.0"
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
-      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/fake-timers": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0"
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4964,20 +4990,20 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
-      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
-        "jest-worker": "30.3.0",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "picomatch": "^4.0.3",
         "walker": "^1.0.8"
       },
@@ -4989,47 +5015,48 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
-      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.3.0",
-        "pretty-format": "30.3.0"
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -5047,14 +5074,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-util": "30.3.0"
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5079,27 +5106,27 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
-      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
+        "jest-haste-map": "30.4.1",
         "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -5108,14 +5135,14 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
-      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.3.0"
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5132,32 +5159,32 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
-      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.3.0",
-        "@jest/environment": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.3.0",
-        "jest-haste-map": "30.3.0",
-        "jest-leak-detector": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-resolve": "30.3.0",
-        "jest-runtime": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-watcher": "30.3.0",
-        "jest-worker": "30.3.0",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -5166,32 +5193,32 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
-      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/fake-timers": "30.3.0",
-        "@jest/globals": "30.3.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.1.0",
         "collect-v8-coverage": "^1.0.2",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.3.0",
-        "jest-snapshot": "30.3.0",
-        "jest-util": "30.3.0",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -5210,9 +5237,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
-      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5221,20 +5248,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.3.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.3.0",
+        "expect": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.3.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-util": "30.3.0",
-        "pretty-format": "30.3.0",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -5243,12 +5270,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -5260,18 +5287,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
-      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5301,19 +5328,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
-      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.3.0",
+        "jest-util": "30.4.1",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -5321,15 +5348,15 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
-      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.3.0",
+        "jest-util": "30.4.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -5510,9 +5537,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.42",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.42.tgz",
-      "integrity": "sha512-oKQFPTibqQwZZkChCDVMFVJXMZdyJNqDWZWYNn8BgyAaK/6yFJEowxCY0RVFirRyWP63hMRuKlkSEd9qlvbWXg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.1.tgz",
+      "integrity": "sha512-GEw0GLL7YUUA6nv21IsCvVjtI5Ejn84sjbdfQ9KxdbqEVOk1PZh7xejn01EEiniKw+dBeCfim+8MGeuvVuE2BA==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -5706,7 +5733,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -5733,9 +5759,9 @@
       "license": "MIT"
     },
     "node_modules/nock": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.14.tgz",
-      "integrity": "sha512-PKk7tex0O3RRXUZC5XDKJ9yM3rYRPS13myduT85VIIYDBnib42Fpxoe6KxRSzqB4iL2NDxkcJ2yiskZ18hGLEQ==",
+      "version": "14.0.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5775,9 +5801,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6238,14 +6264,15 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.0.5",
+        "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6392,10 +6419,18 @@
         "yaml": "^2.4.1"
       }
     },
-    "node_modules/react-is": {
+    "node_modules/react-is-18": {
+      "name": "react-is",
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT"
     },
     "node_modules/readable-stream": {
@@ -6532,9 +6567,9 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6627,9 +6662,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7040,16 +7075,22 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
+      "integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -7171,16 +7212,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
-      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.1",
-        "@typescript-eslint/parser": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7535,9 +7576,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
     "generateConfigurationSchemas": "cs model genCode && perl -pi -e 's|\\@causa/runtime|\\@causa/workspace/validation|g' src/configurations/generated.ts src/scenarios/generated.ts"
   },
   "dependencies": {
-    "@causa/cli": ">= 0.7.0 < 1.0.0",
-    "@causa/workspace": ">= 0.24.1 < 1.0.0",
-    "@scalar/json-magic": "^0.12.11",
-    "@scalar/openapi-parser": "^0.28.1",
+    "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",
+    "@causa/workspace": ">= 0.25.0-beta.2 < 1.0.0",
+    "@scalar/json-magic": "^0.12.12",
+    "@scalar/openapi-parser": "^0.28.2",
     "ajv": "^8.20.0",
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "class-validator": "^0.15.1",
-    "expect": "^30.3.0",
+    "expect": "^30.4.1",
     "globby": "^16.2.0",
     "js-yaml": "^4.1.1",
     "json-e": "^4.8.2",
@@ -59,15 +59,15 @@
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/micromatch": "^4.0.10",
-    "@types/node": "^20.19.39",
+    "@types/node": "^20.19.41",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
-    "jest": "^30.3.0",
+    "jest": "^30.4.2",
     "jest-extended": "^7.0.0",
-    "nock": "^14.0.14",
+    "nock": "^14.0.15",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.1"
+    "typescript-eslint": "^8.59.3"
   }
 }

--- a/src/definitions/event-topic.ts
+++ b/src/definitions/event-topic.ts
@@ -429,11 +429,6 @@ export type BackfillEvent = {
    * Optional attributes for the message.
    */
   readonly attributes?: Record<string, string>;
-
-  /**
-   * Optional ordering key for the message.
-   */
-  readonly key?: string;
 };
 
 /**

--- a/src/definitions/event-topic.ts
+++ b/src/definitions/event-topic.ts
@@ -4,7 +4,7 @@ import {
   CliOption,
   type ParentCliCommandDefinition,
 } from '@causa/cli';
-import { WorkspaceContext, WorkspaceFunction } from '@causa/workspace';
+import { WorkspaceFunction } from '@causa/workspace';
 import { AllowMissing } from '@causa/workspace/validation';
 import { Transform } from 'class-transformer';
 import {
@@ -115,17 +115,15 @@ export abstract class EventTopicListReferencedInProject extends WorkspaceFunctio
    * This is a utility method that can be used by implementations that only retrieve the IDs of the topics from the
    * project's configuration.
    *
-   * @param context The workspace context.
    * @param consumedIds The IDs of the topics that are consumed by the project.
    * @param producedIds The IDs of the topics that are produced by the project.
    * @returns The {@link ReferencedEventTopics} for the project.
    */
   protected async mapToDefinitions(
-    context: WorkspaceContext,
     consumedIds: string[],
     producedIds: string[],
   ): Promise<ReferencedEventTopics> {
-    const allDefinitions = await context.call(EventTopicList, {});
+    const allDefinitions = await this._context.call(EventTopicList, {});
 
     const missingDefinitions: string[] = [];
     const mapTopics = (topics: string[]) =>

--- a/src/functions/causa/configuration-check.ts
+++ b/src/functions/causa/configuration-check.ts
@@ -15,18 +15,18 @@ import {
  * modules, using ajv.
  */
 export class ConfigurationCheckForAll extends ConfigurationCheck {
-  async _call(context: WorkspaceContext): Promise<void> {
-    context.logger.info('🦺 Validating workspace configuration.');
+  async _call(): Promise<void> {
+    this._context.logger.info('🦺 Validating workspace configuration.');
 
-    const validate = await this.buildValidator(context);
+    const validate = await this.buildValidator();
 
     if (this.projects) {
-      await this.validateProjects(context, validate);
+      await this.validateProjects(validate);
     } else {
-      await this.validateContext(context, validate);
+      await this.validateContext(this._context, validate);
     }
 
-    context.logger.info('✅ Configuration is valid.');
+    this._context.logger.info('✅ Configuration is valid.');
   }
 
   _supports(): boolean {
@@ -36,14 +36,13 @@ export class ConfigurationCheckForAll extends ConfigurationCheck {
   /**
    * Builds the ajv validator from the composed configuration schema.
    *
-   * @param context The {@link WorkspaceContext}.
    * @returns The compiled ajv validation function.
    */
-  private async buildValidator(
-    context: WorkspaceContext,
-  ): Promise<ValidateFunction> {
+  private async buildValidator(): Promise<ValidateFunction> {
     const schemaPaths = (
-      await Promise.all(context.callAll(CausaListConfigurationSchemas, {}))
+      await Promise.all(
+        this._context.callAll(CausaListConfigurationSchemas, {}),
+      )
     ).flat();
     const moduleSchemas = await Promise.all(
       schemaPaths.map(async (path) => {
@@ -92,21 +91,17 @@ export class ConfigurationCheckForAll extends ConfigurationCheck {
   /**
    * Validates the configuration for each project in the workspace.
    *
-   * @param context The {@link WorkspaceContext}.
    * @param validate The compiled ajv validation function.
    */
-  private async validateProjects(
-    context: WorkspaceContext,
-    validate: ValidateFunction,
-  ): Promise<void> {
-    const projectPaths = await context.listProjectPaths();
+  private async validateProjects(validate: ValidateFunction): Promise<void> {
+    const projectPaths = await this._context.listProjectPaths();
 
     for (const projectPath of projectPaths) {
-      context.logger.info(
+      this._context.logger.info(
         `📂 Validating configuration for project in '${projectPath}'.`,
       );
 
-      const projectContext = await context.clone({
+      const projectContext = await this._context.clone({
         workingDirectory: projectPath,
         processors: null,
       });

--- a/src/functions/emulator/list.ts
+++ b/src/functions/emulator/list.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { EmulatorList, EmulatorStart } from '../../definitions/index.js';
 
 /**
@@ -7,9 +6,9 @@ import { EmulatorList, EmulatorStart } from '../../definitions/index.js';
  * This should be the only implementation of this function.
  */
 export class EmulatorListForAll extends EmulatorList {
-  async _call(context: WorkspaceContext): Promise<string[]> {
+  async _call(): Promise<string[]> {
     const results = await Promise.all(
-      context.callAll(EmulatorStart, { dryRun: true }),
+      this._context.callAll(EmulatorStart, { dryRun: true }),
     );
     return results.map((r) => r.name);
   }

--- a/src/functions/emulator/start-many.ts
+++ b/src/functions/emulator/start-many.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { NoImplementationFoundError } from '@causa/workspace/function-registry';
 import {
   EmulatorStart,
@@ -11,7 +10,7 @@ import {
  * This should be the only implementation of this function.
  */
 export class EmulatorStartManyForAll extends EmulatorStartMany {
-  async _call(context: WorkspaceContext): Promise<EmulatorStartManyResult> {
+  async _call(): Promise<EmulatorStartManyResult> {
     let emulatorStarts: EmulatorStart[];
     const result: EmulatorStartManyResult = {
       emulatorNames: [],
@@ -21,7 +20,9 @@ export class EmulatorStartManyForAll extends EmulatorStartMany {
     if (this.emulators.length > 0) {
       emulatorStarts = this.emulators.map((name) => {
         try {
-          return context.getFunctionImplementation(EmulatorStart, { name });
+          return this._context.getFunctionImplementation(EmulatorStart, {
+            name,
+          });
         } catch (error) {
           if (error instanceof NoImplementationFoundError) {
             throw new Error(`No implementation found for emulator '${name}'.`);
@@ -31,16 +32,19 @@ export class EmulatorStartManyForAll extends EmulatorStartMany {
         }
       });
     } else {
-      emulatorStarts = context.getFunctionImplementations(EmulatorStart, {});
+      emulatorStarts = this._context.getFunctionImplementations(
+        EmulatorStart,
+        {},
+      );
 
       if (emulatorStarts.length === 0) {
-        context.logger.info('💤 No emulator to start.');
+        this._context.logger.info('💤 No emulator to start.');
         return result;
       }
     }
 
     const emulatorResults = await Promise.all(
-      emulatorStarts.map((emulatorStart) => emulatorStart._call(context)),
+      emulatorStarts.map((emulatorStart) => emulatorStart._call()),
     );
     result.emulatorNames = emulatorResults.map((r) => r.name);
     result.configuration = Object.assign(
@@ -52,7 +56,7 @@ export class EmulatorStartManyForAll extends EmulatorStartMany {
       const confStr = Object.entries(result.configuration)
         .map(([k, v]) => `${k}=${v}`)
         .join('\n');
-      context.logger.info(`🔧 Configuration for emulators:\n${confStr}`);
+      this._context.logger.info(`🔧 Configuration for emulators:\n${confStr}`);
     }
 
     return result;

--- a/src/functions/emulator/stop-many.ts
+++ b/src/functions/emulator/stop-many.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { NoImplementationFoundError } from '@causa/workspace/function-registry';
 import { EmulatorStop, EmulatorStopMany } from '../../definitions/index.js';
 
@@ -7,13 +6,15 @@ import { EmulatorStop, EmulatorStopMany } from '../../definitions/index.js';
  * This should be the only implementation of this function.
  */
 export class EmulatorStopManyForAll extends EmulatorStopMany {
-  async _call(context: WorkspaceContext): Promise<string[]> {
+  async _call(): Promise<string[]> {
     let emulatorStops: EmulatorStop[];
 
     if (this.emulators.length > 0) {
       emulatorStops = this.emulators.map((name) => {
         try {
-          return context.getFunctionImplementation(EmulatorStop, { name });
+          return this._context.getFunctionImplementation(EmulatorStop, {
+            name,
+          });
         } catch (error) {
           if (error instanceof NoImplementationFoundError) {
             throw new Error(`No implementation found for emulator '${name}'.`);
@@ -23,16 +24,19 @@ export class EmulatorStopManyForAll extends EmulatorStopMany {
         }
       });
     } else {
-      emulatorStops = context.getFunctionImplementations(EmulatorStop, {});
+      emulatorStops = this._context.getFunctionImplementations(
+        EmulatorStop,
+        {},
+      );
 
       if (emulatorStops.length === 0) {
-        context.logger.info('💤 No emulator to stop.');
+        this._context.logger.info('💤 No emulator to stop.');
         return [];
       }
     }
 
     const emulatorNames = await Promise.all(
-      emulatorStops.map((emulatorStop) => emulatorStop._call(context)),
+      emulatorStops.map((emulatorStop) => emulatorStop._call()),
     );
 
     return emulatorNames;

--- a/src/functions/environment/deploy.ts
+++ b/src/functions/environment/deploy.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { cloneContextForEnvironmentProjectIfNeeded } from '../../context-utils.js';
 import {
   EnvironmentDeploy,
@@ -11,8 +10,10 @@ import {
  * This should probably not be implemented by any other module.
  */
 export class EnvironmentDeployForAll extends EnvironmentDeploy {
-  async _call(context: WorkspaceContext): Promise<void> {
-    context = await cloneContextForEnvironmentProjectIfNeeded(context);
+  async _call(): Promise<void> {
+    const context = await cloneContextForEnvironmentProjectIfNeeded(
+      this._context,
+    );
 
     await context.call(InfrastructureProcessAndDeploy, {
       deployment: this.deployment,

--- a/src/functions/environment/prepare.ts
+++ b/src/functions/environment/prepare.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { cloneContextForEnvironmentProjectIfNeeded } from '../../context-utils.js';
 import {
   EnvironmentPrepare,
@@ -12,8 +11,10 @@ import {
  * This should probably not be implemented by any other module.
  */
 export class EnvironmentPrepareForAll extends EnvironmentPrepare {
-  async _call(context: WorkspaceContext): Promise<PrepareResult> {
-    context = await cloneContextForEnvironmentProjectIfNeeded(context);
+  async _call(): Promise<PrepareResult> {
+    const context = await cloneContextForEnvironmentProjectIfNeeded(
+      this._context,
+    );
 
     return await context.call(InfrastructureProcessAndPrepare, {
       print: this.print,

--- a/src/functions/event-topic/backfill.ts
+++ b/src/functions/event-topic/backfill.ts
@@ -38,26 +38,24 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
   /**
    * Creates a temporary topic for the backfill or returns the ID of the main topic.
    *
-   * @param context The {@link WorkspaceContext}.
    * @param backfillId The unique ID for the backfilling operation.
    * @returns The ID of the topic to use for publishing events, and the {@link BackfillTemporaryData}.
    */
-  private async setUpTopic(
-    context: WorkspaceContext,
-    backfillId: string,
-  ): Promise<{
+  private async setUpTopic(backfillId: string): Promise<{
     topicId: string;
     temporaryData: BackfillTemporaryData;
   }> {
     const topicId = this.createTemporaryTopic
-      ? await context.call(EventTopicBrokerCreateTopic, {
+      ? await this._context.call(EventTopicBrokerCreateTopic, {
           name: `backfill-${backfillId}`,
         })
-      : await context.call(EventTopicBrokerGetTopicId, {
+      : await this._context.call(EventTopicBrokerGetTopicId, {
           eventTopic: this.eventTopic,
         });
 
-    context.logger.info(`📫 Events will be published to topic '${topicId}'.`);
+    this._context.logger.info(
+      `📫 Events will be published to topic '${topicId}'.`,
+    );
 
     const temporaryData: BackfillTemporaryData = {
       temporaryTopicId: this.createTemporaryTopic ? topicId : null,
@@ -74,21 +72,19 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
    * as working directory and the trigger is forwarded as a {@link EventTopicBrokerTrigger} object. Otherwise, the
    * function is called on the current context with the raw trigger string.
    *
-   * @param context The current {@link WorkspaceContext}.
    * @param backfillId The unique ID for the backfilling operation.
    * @param topicId The ID of the topic to use as trigger.
    * @param trigger The trigger specification to create.
    * @returns The IDs of resources created for the trigger, to be cleaned up after the backfill.
    */
   private async createTrigger(
-    context: WorkspaceContext,
     backfillId: string,
     topicId: string,
     trigger: string,
   ): Promise<string[]> {
     const match = trigger.match(PROJECT_TRIGGER_REGEX);
     if (!match?.groups) {
-      return await context.call(EventTopicBrokerCreateTrigger, {
+      return await this._context.call(EventTopicBrokerCreateTrigger, {
         backfillId,
         topicId,
         trigger,
@@ -99,8 +95,8 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
 
     let projectContext: WorkspaceContext;
     try {
-      const workingDirectory = join(context.rootPath, projectPath);
-      projectContext = await context.clone({ workingDirectory });
+      const workingDirectory = join(this._context.rootPath, projectPath);
+      projectContext = await this._context.clone({ workingDirectory });
     } catch (error: any) {
       throw new EventTopicTriggerCreationError(error, []);
     }
@@ -127,13 +123,11 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
   /**
    * Creates temporary triggers for the backfill, and fills the {@link BackfillTemporaryData} accordingly.
    *
-   * @param context The {@link WorkspaceContext}.
    * @param backfillId The unique ID for the backfilling operation.
    * @param topicId The ID of the topic to use as trigger.
    * @param data The {@link BackfillTemporaryData} to fill with crated temporary resource IDs.
    */
   private async createTriggers(
-    context: WorkspaceContext,
     backfillId: string,
     topicId: string,
     data: BackfillTemporaryData,
@@ -142,13 +136,12 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
       return;
     }
 
-    context.logger.info('🧱 Creating event triggers.');
+    this._context.logger.info('🧱 Creating event triggers.');
 
     const results = await Promise.allSettled(
       this.triggers.map(async (trigger) => {
         try {
           const resourceIds = await this.createTrigger(
-            context,
             backfillId,
             topicId,
             trigger,
@@ -173,7 +166,7 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
     }
   }
 
-  async _call(context: WorkspaceContext): Promise<string> {
+  async _call(): Promise<string> {
     if (this.createTemporaryTopic && !this.triggers?.length) {
       throw new Error(
         'At least one temporary trigger should be defined when using a temporary topic.',
@@ -181,45 +174,47 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
     }
 
     const backfillId = randomBytes(3).toString('hex');
-    context.logger.info(`🎉 Initializing backfill with ID '${backfillId}'.`);
-
-    const { topicId, temporaryData } = await this.setUpTopic(
-      context,
-      backfillId,
+    this._context.logger.info(
+      `🎉 Initializing backfill with ID '${backfillId}'.`,
     );
+
+    const { topicId, temporaryData } = await this.setUpTopic(backfillId);
 
     const backfillFile = this.output
       ? resolve(this.output)
-      : join(context.rootPath, `backfill-${backfillId}.json`);
+      : join(this._context.rootPath, `backfill-${backfillId}.json`);
     const cleanBackfillCommand = [
       'cs',
       'events',
       'cleanBackfill',
-      ...(context.environment ? ['-e', context.environment] : []),
+      ...(this._context.environment ? ['-e', this._context.environment] : []),
       `"${backfillFile}"`,
     ].join(' ');
 
     try {
-      await this.createTriggers(context, backfillId, topicId, temporaryData);
+      await this.createTriggers(backfillId, topicId, temporaryData);
 
-      const eventsSource = await context.call(EventTopicCreateBackfillSource, {
-        eventTopic: this.eventTopic,
-        source: this.source,
-        filter: this.filter,
-      });
+      const eventsSource = await this._context.call(
+        EventTopicCreateBackfillSource,
+        {
+          eventTopic: this.eventTopic,
+          source: this.source,
+          filter: this.filter,
+        },
+      );
 
-      await context.call(EventTopicBrokerPublishEvents, {
+      await this._context.call(EventTopicBrokerPublishEvents, {
         topicId,
         eventTopic: this.eventTopic,
         source: () => eventsSource,
       });
 
-      context.logger.info('✅ Successfully published all events.');
-      context.logger.info(
+      this._context.logger.info('✅ Successfully published all events.');
+      this._context.logger.info(
         `💡 Once backfilling is complete, temporary resources can be cleaned using '${cleanBackfillCommand}'.`,
       );
     } catch (error) {
-      context.logger.warn(
+      this._context.logger.warn(
         `⚠️ Backfilling failed but there might be temporary resources to clean up using '${cleanBackfillCommand}'.`,
       );
       throw error;

--- a/src/functions/event-topic/clean-backfill.ts
+++ b/src/functions/event-topic/clean-backfill.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { readFile } from 'fs/promises';
 import {
   type BackfillTemporaryData,
@@ -13,22 +12,24 @@ import {
  * resources listed in the backfill file.
  */
 export class EventTopicCleanBackfillForAll extends EventTopicCleanBackfill {
-  async _call(context: WorkspaceContext): Promise<void> {
+  async _call(): Promise<void> {
     const dataBuffer = await readFile(this.file);
     const data: BackfillTemporaryData = JSON.parse(dataBuffer.toString());
 
-    context.logger.info('🔥 Removing temporary backfill resources.');
+    this._context.logger.info('🔥 Removing temporary backfill resources.');
 
     const resourceIdsAndPromises = data.temporaryTriggerResourceIds.map(
       (id) => ({
         id,
-        promise: context.call(EventTopicBrokerDeleteTriggerResource, { id }),
+        promise: this._context.call(EventTopicBrokerDeleteTriggerResource, {
+          id,
+        }),
       }),
     );
     if (data.temporaryTopicId) {
       resourceIdsAndPromises.push({
         id: data.temporaryTopicId,
-        promise: context.call(EventTopicBrokerDeleteTopic, {
+        promise: this._context.call(EventTopicBrokerDeleteTopic, {
           id: data.temporaryTopicId,
         }),
       });
@@ -41,7 +42,7 @@ export class EventTopicCleanBackfillForAll extends EventTopicCleanBackfill {
           return true;
         } catch (error: any) {
           const message = error.message ?? error;
-          context.logger.error(
+          this._context.logger.error(
             `❌ Failed to delete resource '${id}': '${message}'.`,
           );
           return false;
@@ -50,7 +51,7 @@ export class EventTopicCleanBackfillForAll extends EventTopicCleanBackfill {
     );
 
     if (results.every((r) => r)) {
-      context.logger.info(
+      this._context.logger.info(
         '✅ Successfully cleaned resources for the backfill.',
       );
     } else {

--- a/src/functions/event-topic/create-backfill-source-json-files.spec.ts
+++ b/src/functions/event-topic/create-backfill-source-json-files.spec.ts
@@ -48,7 +48,7 @@ describe('EventTopicCreateBackfillSourceFromJsonFiles', () => {
       fileA,
       [
         JSON.stringify({ data: 'a1', attributes: { i: '0' } }),
-        JSON.stringify({ data: 'a2', key: 'k' }),
+        JSON.stringify({ data: 'a2' }),
       ].join('\n'),
     );
     await writeFile(fileB, JSON.stringify({ data: 'b1' }));
@@ -60,9 +60,9 @@ describe('EventTopicCreateBackfillSourceFromJsonFiles', () => {
 
     const events = await Array.fromAsync(iterable);
     expect(events).toEqual([
-      { data: Buffer.from('a1'), attributes: { i: '0' }, key: undefined },
-      { data: Buffer.from('a2'), attributes: undefined, key: 'k' },
-      { data: Buffer.from('b1'), attributes: undefined, key: undefined },
+      { data: Buffer.from('a1'), attributes: { i: '0' } },
+      { data: Buffer.from('a2'), attributes: undefined },
+      { data: Buffer.from('b1'), attributes: undefined },
     ]);
   });
 
@@ -80,7 +80,7 @@ describe('EventTopicCreateBackfillSourceFromJsonFiles', () => {
 
     const events = await Array.fromAsync(iterable);
     expect(events).toEqual([
-      { data: Buffer.from('ok'), attributes: undefined, key: undefined },
+      { data: Buffer.from('ok'), attributes: undefined },
     ]);
   });
 

--- a/src/functions/event-topic/create-backfill-source-json-files.ts
+++ b/src/functions/event-topic/create-backfill-source-json-files.ts
@@ -65,9 +65,7 @@ async function* iterateJsonFiles(
  * optional `key` fields. Filtering is not supported.
  */
 export class EventTopicCreateBackfillSourceFromJsonFiles extends EventTopicCreateBackfillSource {
-  async _call(
-    context: WorkspaceContext,
-  ): Promise<AsyncIterable<BackfillEvent>> {
+  async _call(): Promise<AsyncIterable<BackfillEvent>> {
     if (this.filter) {
       throw new Error('Filtering JSON events from files is not supported.');
     }
@@ -84,7 +82,7 @@ export class EventTopicCreateBackfillSourceFromJsonFiles extends EventTopicCreat
       followSymbolicLinks: false,
     });
 
-    return iterateJsonFiles(context, files.sort());
+    return iterateJsonFiles(this._context, files.sort());
   }
 
   _supports(): boolean {

--- a/src/functions/event-topic/create-backfill-source-json-files.ts
+++ b/src/functions/event-topic/create-backfill-source-json-files.ts
@@ -26,7 +26,7 @@ function parseEvent(
   try {
     const event = JSON.parse(line);
     const data = Buffer.from(event.data);
-    return { data, attributes: event.attributes, key: event.key };
+    return { data, attributes: event.attributes };
   } catch (error) {
     context.logger.error(`❌ Failed to parse event '${line}': '${error}'.`);
     return null;
@@ -61,8 +61,8 @@ async function* iterateJsonFiles(
 
 /**
  * Implements {@link EventTopicCreateBackfillSource} for `json://<glob>` sources.
- * Each matched file is expected to contain newline-delimited JSON events with `data`, optional `attributes`, and
- * optional `key` fields. Filtering is not supported.
+ * Each matched file is expected to contain newline-delimited JSON events with `data` and optional `attributes` fields.
+ * Filtering is not supported.
  */
 export class EventTopicCreateBackfillSourceFromJsonFiles extends EventTopicCreateBackfillSource {
   async _call(): Promise<AsyncIterable<BackfillEvent>> {

--- a/src/functions/event-topic/list-referenced-in-project-serverless-functions.ts
+++ b/src/functions/event-topic/list-referenced-in-project-serverless-functions.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import {
   EventTopicListReferencedInProject,
   type ReferencedEventTopics,
@@ -11,9 +10,9 @@ import type { ServerlessFunctionsConfiguration } from '../../index.js';
  * The produced topics are the ones listed as outputs of the functions.
  */
 export class EventTopicListReferencedInProjectForServerlessFunctions extends EventTopicListReferencedInProject {
-  async _call(context: WorkspaceContext): Promise<ReferencedEventTopics> {
+  async _call(): Promise<ReferencedEventTopics> {
     const functions = Object.values(
-      context
+      this._context
         .asConfiguration<ServerlessFunctionsConfiguration>()
         .get('serverlessFunctions.functions', { unsafe: true }) ?? {},
     );
@@ -32,10 +31,10 @@ export class EventTopicListReferencedInProjectForServerlessFunctions extends Eve
       ...new Set(functions.flatMap((fn) => fn.outputs?.eventTopics ?? [])),
     ];
 
-    return await this.mapToDefinitions(context, consumed, produced);
+    return await this.mapToDefinitions(consumed, produced);
   }
 
-  _supports(context: WorkspaceContext) {
-    return context.get('project.type') === 'serverlessFunctions';
+  _supports() {
+    return this._context.get('project.type') === 'serverlessFunctions';
   }
 }

--- a/src/functions/event-topic/list-referenced-in-project-service-container.ts
+++ b/src/functions/event-topic/list-referenced-in-project-service-container.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import type { ServiceContainerConfiguration } from '../../configurations/index.js';
 import {
   EventTopicListReferencedInProject,
@@ -11,9 +10,9 @@ import {
  * The produced topics are the ones listed as outputs to the service.
  */
 export class EventTopicListReferencedInProjectForServiceContainer extends EventTopicListReferencedInProject {
-  async _call(context: WorkspaceContext): Promise<ReferencedEventTopics> {
+  async _call(): Promise<ReferencedEventTopics> {
     const serviceContainerConf =
-      context.asConfiguration<ServiceContainerConfiguration>();
+      this._context.asConfiguration<ServiceContainerConfiguration>();
     const triggers =
       serviceContainerConf.get('serviceContainer.triggers', { unsafe: true }) ??
       {};
@@ -31,10 +30,10 @@ export class EventTopicListReferencedInProjectForServiceContainer extends EventT
       ),
     ];
 
-    return await this.mapToDefinitions(context, consumed, produced);
+    return await this.mapToDefinitions(consumed, produced);
   }
 
-  _supports(context: WorkspaceContext): boolean {
-    return context.get('project.type') === 'serviceContainer';
+  _supports(): boolean {
+    return this._context.get('project.type') === 'serviceContainer';
   }
 }

--- a/src/functions/event-topic/list.ts
+++ b/src/functions/event-topic/list.ts
@@ -1,4 +1,4 @@
-import { WorkspaceContext, listFilesAndFormat } from '@causa/workspace';
+import { listFilesAndFormat } from '@causa/workspace';
 import type { EventsConfiguration } from '../../configurations/index.js';
 import {
   DuplicateEventTopicError,
@@ -28,8 +28,8 @@ const DEFAULT_TOPIC_REGULAR_EXPRESSION =
  * by any other plugin.
  */
 export class EventTopicListForAll extends EventTopicList {
-  async _call(context: WorkspaceContext): Promise<EventTopicDefinition[]> {
-    const eventsConf = context.asConfiguration<EventsConfiguration>();
+  async _call(): Promise<EventTopicDefinition[]> {
+    const eventsConf = this._context.asConfiguration<EventsConfiguration>();
     const format =
       eventsConf.get('events.topics.format') ?? DEFAULT_TOPIC_ID_FORMAT;
     const globs = eventsConf.get('events.topics.globs') ?? DEFAULT_TOPIC_GLOBS;
@@ -41,10 +41,10 @@ export class EventTopicListForAll extends EventTopicList {
       globs,
       regExp,
       format,
-      context.rootPath,
+      this._context.rootPath,
       {
         nonMatchingPathHandler: (path) =>
-          context.logger.warn(
+          this._context.logger.warn(
             `📂 Path '${path}' matches the event topic globs but did not match the regular expression. It will be ignored from the schema definition files.`,
           ),
       },

--- a/src/functions/http/make-request.ts
+++ b/src/functions/http/make-request.ts
@@ -1,11 +1,10 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { type HttpResponse, HttpMakeRequest } from '../../definitions/index.js';
 
 /**
  * Implements {@link HttpMakeRequest} using the native `fetch` API.
  */
 export class HttpMakeRequestForAll extends HttpMakeRequest {
-  async _call(context: WorkspaceContext): Promise<HttpResponse> {
+  async _call(): Promise<HttpResponse> {
     const method = (this.method ?? 'GET').toUpperCase();
     const path = this.path ?? '/';
     const baseUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(this.baseUrl)
@@ -33,7 +32,7 @@ export class HttpMakeRequestForAll extends HttpMakeRequest {
       }
     }
 
-    context.logger.debug(`Making HTTP call '${method} ${url}'.`);
+    this._context.logger.debug(`Making HTTP call '${method} ${url}'.`);
 
     const response = await fetch(url, { method, headers, body });
 

--- a/src/functions/infrastructure/process-and-deploy.ts
+++ b/src/functions/infrastructure/process-and-deploy.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { wrapInfrastructureOperation } from '../../context-utils.js';
 import {
   InfrastructureDeploy,
@@ -11,8 +10,8 @@ import {
  * This should probably not be implemented by any other module.
  */
 export class InfrastructureProcessAndDeployForAll extends InfrastructureProcessAndDeploy {
-  async _call(context: WorkspaceContext): Promise<void> {
-    return await wrapInfrastructureOperation(context, (context) =>
+  async _call(): Promise<void> {
+    return await wrapInfrastructureOperation(this._context, (context) =>
       context.call(InfrastructureDeploy, { deployment: this.deployment }),
     );
   }

--- a/src/functions/infrastructure/process-and-prepare.ts
+++ b/src/functions/infrastructure/process-and-prepare.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { wrapInfrastructureOperation } from '../../context-utils.js';
 import {
   InfrastructurePrepare,
@@ -12,8 +11,8 @@ import {
  * This should probably not be implemented by any other module.
  */
 export class InfrastructureProcessAndPrepareForAll extends InfrastructureProcessAndPrepare {
-  async _call(context: WorkspaceContext): Promise<PrepareResult> {
-    return await wrapInfrastructureOperation(context, (context) =>
+  async _call(): Promise<PrepareResult> {
+    return await wrapInfrastructureOperation(this._context, (context) =>
       context.call(InfrastructurePrepare, {
         print: this.print,
         destroy: this.destroy,

--- a/src/functions/model/generate-code.ts
+++ b/src/functions/model/generate-code.ts
@@ -1,4 +1,3 @@
-import type { WorkspaceContext } from '@causa/workspace';
 import { NoImplementationFoundError } from '@causa/workspace/function-registry';
 import type { ModelConfiguration } from '../../configurations/index.js';
 import {
@@ -12,9 +11,9 @@ import {
  * This should be the only implementation, as it only iterates over the configured code generators generically.
  */
 export class ModelGenerateCodeForAll extends ModelGenerateCode {
-  async _call(context: WorkspaceContext): Promise<GeneratorsOutput> {
+  async _call(): Promise<GeneratorsOutput> {
     const generators =
-      context
+      this._context
         .asConfiguration<ModelConfiguration>()
         .get('model.codeGenerators') ?? [];
     if (generators.length === 0) {
@@ -28,9 +27,11 @@ export class ModelGenerateCodeForAll extends ModelGenerateCode {
       const { generator, ...configuration } = generatorAndConfiguration;
 
       try {
-        context.logger.info(`🔨 Running code generator '${generator}'...`);
+        this._context.logger.info(
+          `🔨 Running code generator '${generator}'...`,
+        );
 
-        output[generator] = await context.call(ModelRunCodeGenerator, {
+        output[generator] = await this._context.call(ModelRunCodeGenerator, {
           generator,
           configuration,
           previousGeneratorsOutput: output,
@@ -52,12 +53,12 @@ export class ModelGenerateCodeForAll extends ModelGenerateCode {
     }
 
     if (missingGenerators.length > 0) {
-      context.logger.warn(
+      this._context.logger.warn(
         `The following generators were not found or do not match the current project configuration: ${missingGenerators.map((g) => `'${g}'`).join(', ')}.`,
       );
     }
 
-    context.logger.info('✅ Code generation completed successfully.');
+    this._context.logger.info('✅ Code generation completed successfully.');
 
     return output;
   }

--- a/src/functions/model/make-generator-quicktype-input-data.call.ts
+++ b/src/functions/model/make-generator-quicktype-input-data.call.ts
@@ -1,4 +1,3 @@
-import type { WorkspaceContext } from '@causa/workspace';
 import type { InputData } from 'quicktype-core';
 import { makeJsonSchemaInputData } from '../../code-generation/index.js';
 import { ModelParseCodeGeneratorInputs } from '../../definitions/index.js';
@@ -6,12 +5,11 @@ import type { ModelMakeGeneratorQuicktypeInputDataForJsonSchema } from './make-g
 
 export default async function call(
   this: ModelMakeGeneratorQuicktypeInputDataForJsonSchema,
-  context: WorkspaceContext,
 ): Promise<InputData> {
-  const { files, nestedSchemas, includeFullReferences } = await context.call(
-    ModelParseCodeGeneratorInputs,
-    { configuration: this.configuration },
-  );
+  const { files, nestedSchemas, includeFullReferences } =
+    await this._context.call(ModelParseCodeGeneratorInputs, {
+      configuration: this.configuration,
+    });
 
   return await makeJsonSchemaInputData(files, {
     nestedSchemas,

--- a/src/functions/model/make-generator-quicktype-input-data.ts
+++ b/src/functions/model/make-generator-quicktype-input-data.ts
@@ -1,4 +1,4 @@
-import { callDeferred, type WorkspaceContext } from '@causa/workspace';
+import { callDeferred } from '@causa/workspace';
 import type { InputData } from 'quicktype-core';
 import type { ModelConfiguration } from '../../configurations/index.js';
 import { ModelMakeGeneratorQuicktypeInputData } from '../../definitions/index.js';
@@ -9,14 +9,15 @@ import { ModelMakeGeneratorQuicktypeInputData } from '../../definitions/index.js
  * configuration.
  */
 export class ModelMakeGeneratorQuicktypeInputDataForJsonSchema extends ModelMakeGeneratorQuicktypeInputData {
-  async _call(context: WorkspaceContext): Promise<InputData> {
-    return await callDeferred(this, context, import.meta.url);
+  async _call(): Promise<InputData> {
+    return await callDeferred(this, import.meta.url);
   }
 
-  _supports(context: WorkspaceContext): boolean {
+  _supports(): boolean {
     return (
-      context.asConfiguration<ModelConfiguration>().get('model.schema') ===
-      'jsonschema'
+      this._context
+        .asConfiguration<ModelConfiguration>()
+        .get('model.schema') === 'jsonschema'
     );
   }
 }

--- a/src/functions/model/parse-code-generator-inputs.ts
+++ b/src/functions/model/parse-code-generator-inputs.ts
@@ -1,4 +1,3 @@
-import type { WorkspaceContext } from '@causa/workspace';
 import { globby } from 'globby';
 import { resolve } from 'path';
 import {
@@ -12,8 +11,8 @@ import {
  * This parses the standard code generator configuration and returns the list of input files.
  */
 export class ModelParseCodeGeneratorInputsForAll extends ModelParseCodeGeneratorInputs {
-  async _call(context: WorkspaceContext): Promise<CodeGeneratorInputs> {
-    const projectPath = context.getProjectPathOrThrow();
+  async _call(): Promise<CodeGeneratorInputs> {
+    const projectPath = this._context.getProjectPathOrThrow();
 
     const includeEvents = this.configuration.includeEvents ?? false;
     if (includeEvents !== undefined && typeof includeEvents !== 'boolean') {
@@ -56,9 +55,11 @@ export class ModelParseCodeGeneratorInputsForAll extends ModelParseCodeGenerator
     const filesSet = new Set<string>();
 
     if (includeEvents) {
-      context.logger.debug('Listing event topics referenced in the project.');
+      this._context.logger.debug(
+        'Listing event topics referenced in the project.',
+      );
 
-      const { consumed, produced } = await context.call(
+      const { consumed, produced } = await this._context.call(
         EventTopicListReferencedInProject,
         {},
       );
@@ -67,7 +68,7 @@ export class ModelParseCodeGeneratorInputsForAll extends ModelParseCodeGenerator
     }
 
     if (globs.length > 0) {
-      context.logger.debug(
+      this._context.logger.debug(
         'Listing schemas from globs configured for the generator.',
       );
 
@@ -79,7 +80,7 @@ export class ModelParseCodeGeneratorInputsForAll extends ModelParseCodeGenerator
     }
 
     const files = Array.from(filesSet);
-    context.logger.debug(
+    this._context.logger.debug(
       `Found input schema files to generate:\n${files.join('\n')}`,
     );
 

--- a/src/functions/openapi/generate-specification-project.call.ts
+++ b/src/functions/openapi/generate-specification-project.call.ts
@@ -1,4 +1,3 @@
-import type { WorkspaceContext } from '@causa/workspace';
 import { join as joinSpecs } from '@scalar/openapi-parser';
 import type { OpenAPIV3_1 } from '@scalar/openapi-types';
 import { readFile, writeFile } from 'fs/promises';
@@ -44,20 +43,21 @@ async function loadAndRewriteRefs(
 
 export default async function call(
   this: OpenApiGenerateSpecificationForProjectByMerging,
-  context: WorkspaceContext,
 ): Promise<string> {
-  const openApiConf = context.asConfiguration<OpenApiConfiguration>();
+  const openApiConf = this._context.asConfiguration<OpenApiConfiguration>();
   const specificationGlobs = openApiConf.get('openApi.specifications') ?? [];
   const globalSpec: OpenAPIV3_1.Document =
     openApiConf.get('openApi.global') ?? {};
-  const projectPath = context.getProjectPathOrThrow();
+  const projectPath = this._context.getProjectPathOrThrow();
 
   const output = this.output
     ? resolve(this.output)
     : join(projectPath, DEFAULT_OPENAPI_OUTPUT);
   const outputDir = dirname(output);
 
-  context.logger.info(`📝 Resolving OpenAPI specification globs for project.`);
+  this._context.logger.info(
+    `📝 Resolving OpenAPI specification globs for project.`,
+  );
 
   const specFiles = await globby(specificationGlobs, {
     cwd: projectPath,
@@ -71,7 +71,7 @@ export default async function call(
     ),
   );
 
-  context.logger.info(
+  this._context.logger.info(
     `📝 Merging ${specifications.length} OpenAPI specification(s).`,
   );
 
@@ -89,7 +89,7 @@ export default async function call(
   }
 
   const mergedSpecificationsYaml = dump(result.document);
-  context.logger.info(`✅ Merged OpenAPI specifications.`);
+  this._context.logger.info(`✅ Merged OpenAPI specifications.`);
 
   if (this.returnSpecification) {
     return mergedSpecificationsYaml;

--- a/src/functions/openapi/generate-specification-project.ts
+++ b/src/functions/openapi/generate-specification-project.ts
@@ -1,4 +1,4 @@
-import { callDeferred, type WorkspaceContext } from '@causa/workspace';
+import { callDeferred } from '@causa/workspace';
 import type { OpenApiConfiguration } from '../../configurations/index.js';
 import { OpenApiGenerateSpecification } from '../../definitions/index.js';
 
@@ -7,13 +7,13 @@ import { OpenApiGenerateSpecification } from '../../definitions/index.js';
  * patterns configured in `openApi.specifications`.
  */
 export class OpenApiGenerateSpecificationForProjectByMerging extends OpenApiGenerateSpecification {
-  async _call(context: WorkspaceContext): Promise<string> {
-    return await callDeferred(this, context, import.meta.url);
+  async _call(): Promise<string> {
+    return await callDeferred(this, import.meta.url);
   }
 
-  _supports(context: WorkspaceContext): boolean {
-    const projectDefined = context.get('project') !== undefined;
-    const specifications = context
+  _supports(): boolean {
+    const projectDefined = this._context.get('project') !== undefined;
+    const specifications = this._context
       .asConfiguration<OpenApiConfiguration>()
       .get('openApi.specifications');
     return projectDefined && Array.isArray(specifications);

--- a/src/functions/openapi/generate-specification-workspace.call.ts
+++ b/src/functions/openapi/generate-specification-workspace.call.ts
@@ -202,27 +202,26 @@ function deduplicateComponents(
 
 export default async function call(
   this: OpenApiGenerateSpecificationForWorkspace,
-  context: WorkspaceContext,
 ): Promise<string> {
   const output = this.output
     ? resolve(this.output)
-    : join(context.rootPath, DEFAULT_OPENAPI_OUTPUT);
-  const projectPaths = await context.listProjectPaths();
+    : join(this._context.rootPath, DEFAULT_OPENAPI_OUTPUT);
+  const projectPaths = await this._context.listProjectPaths();
 
   const openApiSpecifications = await Promise.all(
     projectPaths.map((projectPath) =>
-      generateForProject(context, projectPath, output),
+      generateForProject(this._context, projectPath, output),
     ),
   );
 
-  context.logger.info(`📝 Merging OpenAPI specifications.`);
+  this._context.logger.info(`📝 Merging OpenAPI specifications.`);
   const mergedSpecifications = await mergeSpecifications(
-    context,
+    this._context,
     openApiSpecifications.filter((spec) => spec !== null),
   );
-  context.logger.info(`✅ Merged OpenAPI specifications.`);
+  this._context.logger.info(`✅ Merged OpenAPI specifications.`);
 
-  context.logger.info(`📦 Bundling external references.`);
+  this._context.logger.info(`📦 Bundling external references.`);
   await bundle(mergedSpecifications, {
     plugins: [readFiles()],
     treeShake: true,

--- a/src/functions/openapi/generate-specification-workspace.ts
+++ b/src/functions/openapi/generate-specification-workspace.ts
@@ -1,4 +1,4 @@
-import { callDeferred, type WorkspaceContext } from '@causa/workspace';
+import { callDeferred } from '@causa/workspace';
 import { OpenApiGenerateSpecification } from '../../definitions/index.js';
 
 /**
@@ -7,15 +7,15 @@ import { OpenApiGenerateSpecification } from '../../definitions/index.js';
  * which the generation is not supported. Then, it merges all the generated documentation into a single file.
  */
 export class OpenApiGenerateSpecificationForWorkspace extends OpenApiGenerateSpecification {
-  async _call(context: WorkspaceContext): Promise<string> {
-    return await callDeferred(this, context, import.meta.url);
+  async _call(): Promise<string> {
+    return await callDeferred(this, import.meta.url);
   }
 
-  _supports(context: WorkspaceContext): boolean {
+  _supports(): boolean {
     return (
-      context.get('project.name') === undefined &&
-      context.get('project.type') === undefined &&
-      context.get('project.language') === undefined
+      this._context.get('project.name') === undefined &&
+      this._context.get('project.type') === undefined &&
+      this._context.get('project.language') === undefined
     );
   }
 }

--- a/src/functions/project/dependencies-update-and-test.ts
+++ b/src/functions/project/dependencies-update-and-test.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { NoImplementationFoundError } from '@causa/workspace/function-registry';
 import {
   ProjectDependenciesUpdate,
@@ -16,43 +15,45 @@ import {
  * {@link ProjectTest} is optional, but a warning will be logged if it is not available.
  */
 export class ProjectDependenciesUpdateAndTestForAll extends ProjectDependenciesUpdateAndTest {
-  async _call(context: WorkspaceContext): Promise<void> {
+  async _call(): Promise<void> {
     let shouldRunTests = !this.skipTest;
 
     if (shouldRunTests) {
       try {
-        context.logger.debug('Running tests before updating dependencies.');
-        await context.call(ProjectTest, {});
+        this._context.logger.debug(
+          'Running tests before updating dependencies.',
+        );
+        await this._context.call(ProjectTest, {});
       } catch (error) {
         if (!(error instanceof NoImplementationFoundError)) {
           throw error;
         }
 
-        context.logger.warn(
+        this._context.logger.warn(
           '⚠️ No implementation exists to run tests for the project, skipping them.',
         );
         shouldRunTests = false;
       }
     }
 
-    const didUpdate = await context.call(ProjectDependenciesUpdate, {});
+    const didUpdate = await this._context.call(ProjectDependenciesUpdate, {});
 
     if (!shouldRunTests) {
       return;
     }
 
     if (!didUpdate) {
-      context.logger.debug(
+      this._context.logger.debug(
         'Dependencies were not updated, skipping tests after updating dependencies.',
       );
       return;
     }
 
     try {
-      context.logger.debug('Running tests after updating dependencies.');
-      await context.call(ProjectTest, {});
+      this._context.logger.debug('Running tests after updating dependencies.');
+      await this._context.call(ProjectTest, {});
     } catch (error) {
-      context.logger.error(
+      this._context.logger.error(
         '❌ Tests failed after updating dependencies, you may want to rollback the update or fix the tests before continuing.',
       );
 

--- a/src/functions/project/diff.ts
+++ b/src/functions/project/diff.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import micromatch from 'micromatch';
 import { join } from 'path';
 import {
@@ -19,16 +18,14 @@ export class ProjectDiffForAll extends ProjectDiff {
    * `project.externalFiles` configuration has changed.
    *
    * @param projectPath The path to the project to check for changes.
-   * @param context The {@link WorkspaceContext}.
    * @param filesDiff The files that have changed in the repository, according to Git.
    * @returns The diff result for the project, or `null` if no changes were found.
    */
   private async checkDiffForProjectPath(
     projectPath: string,
-    context: WorkspaceContext,
     filesDiff: string[],
   ): Promise<ProjectDiffResult[string] | null> {
-    const projectContext = await context.clone({
+    const projectContext = await this._context.clone({
       workingDirectory: projectPath,
       processors: null,
     });
@@ -36,23 +33,25 @@ export class ProjectDiffForAll extends ProjectDiff {
     const patterns = projectContext.get('project.externalFiles') ?? [];
     const globs = [
       join(projectPath, '**', '*'),
-      ...patterns.map((d) => join(context.rootPath, d)),
+      ...patterns.map((d) => join(this._context.rootPath, d)),
     ];
 
     const diff = micromatch(filesDiff, globs);
     if (diff.length === 0) {
-      context.logger.debug(`No change found in project '${projectPath}'.`);
+      this._context.logger.debug(
+        `No change found in project '${projectPath}'.`,
+      );
       return null;
     }
 
-    context.logger.debug(
+    this._context.logger.debug(
       `Changes found in project '${projectPath}', generating project configuration.`,
     );
     const configuration = await projectContext.getAndRender('project');
     return { diff, configuration };
   }
 
-  async _call(context: WorkspaceContext): Promise<ProjectDiffResult> {
+  async _call(): Promise<ProjectDiffResult> {
     const commits = this.commits ?? [];
     if (commits.length > 2) {
       throw new Error(
@@ -60,28 +59,28 @@ export class ProjectDiffForAll extends ProjectDiff {
       );
     }
 
-    context.logger.info('🔍 Checking for changes in projects.');
+    this._context.logger.info('🔍 Checking for changes in projects.');
 
-    const gitService = context.service(GitService);
+    const gitService = this._context.service(GitService);
 
     const [projectPaths, repoRoot, filesDiff] = await Promise.all([
-      context.listProjectPaths(),
+      this._context.listProjectPaths(),
       gitService.getRepositoryRootPath(),
       gitService.filesDiff({ commits }),
     ]);
     const absoluteFilesDiff = filesDiff.map((f) => join(repoRoot, f));
 
-    context.logger.debug(
+    this._context.logger.debug(
       `Git diff returned files: ${filesDiff.map((f) => `'${f}'`).join(', ')}.`,
     );
-    context.logger.debug(
+    this._context.logger.debug(
       `Checking ${projectPaths.length} projects for changes.`,
     );
 
     const changedProjectsEntries = await Promise.all(
       projectPaths.map(async (p) => [
         p,
-        await this.checkDiffForProjectPath(p, context, absoluteFilesDiff),
+        await this.checkDiffForProjectPath(p, absoluteFilesDiff),
       ]),
     );
 

--- a/src/functions/project/init-workspace.ts
+++ b/src/functions/project/init-workspace.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import {
   CAUSA_FOLDER,
   setUpCausaFolder,
@@ -18,50 +17,50 @@ import {
  * However, if the `force` option is provided, the Causa folder will be reinitialized.
  */
 export class ProjectInitForWorkspace extends ProjectInit {
-  async _call(context: WorkspaceContext): Promise<void> {
+  async _call(): Promise<void> {
     if (this.force) {
-      context.logger.info('🔥 Forcing reinstallation of Causa modules.');
+      this._context.logger.info('🔥 Forcing reinstallation of Causa modules.');
 
-      const currentDependencies = await this.readCurrentDependencies(context);
+      const currentDependencies = await this.readCurrentDependencies();
       // Merging the current dependencies allows keeping the ones that are not defined in the configuration, but might
       // have been specified by a different process, e.g. the CLI.
       const modules = {
         ...currentDependencies,
-        ...(context.get('causa.modules') ?? {}),
+        ...(this._context.get('causa.modules') ?? {}),
       };
 
-      await setUpCausaFolder(context.rootPath, modules, context.logger);
+      await setUpCausaFolder(
+        this._context.rootPath,
+        modules,
+        this._context.logger,
+      );
 
-      context.logger.info(
+      this._context.logger.info(
         '✅ Successfully initialized workspace dependencies.',
       );
-      context.logger.warn(
+      this._context.logger.warn(
         `⚠️ Rerun initialization without force to complete the initialization using the new modules.`,
       );
 
       return;
     }
 
-    await this.writeConfigurationSchema(context);
+    await this.writeConfigurationSchema();
   }
 
-  _supports(context: WorkspaceContext): boolean {
-    return this.workspace || context.get('project.name') === undefined;
+  _supports(): boolean {
+    return this.workspace || this._context.get('project.name') === undefined;
   }
 
   /**
    * Collects configuration schemas from all modules and writes a combined schema file in the Causa folder.
-   *
-   * @param context The {@link WorkspaceContext}.
    */
-  private async writeConfigurationSchema(
-    context: WorkspaceContext,
-  ): Promise<void> {
+  private async writeConfigurationSchema(): Promise<void> {
     const schemaPaths = await Promise.all(
-      context.callAll(CausaListConfigurationSchemas, {}),
+      this._context.callAll(CausaListConfigurationSchemas, {}),
     );
     const schemaFile = join(
-      context.rootPath,
+      this._context.rootPath,
       CAUSA_FOLDER,
       'configuration-schema.yaml',
     );
@@ -75,26 +74,25 @@ export class ProjectInitForWorkspace extends ProjectInit {
     const content = dump(schema);
     await writeFile(schemaFile, content);
 
-    context.logger.info(`📝 Wrote configuration schema to '${schemaFile}'.`);
+    this._context.logger.info(
+      `📝 Wrote configuration schema to '${schemaFile}'.`,
+    );
   }
 
   /**
    * Parses the currently installed dependencies in the Causa folder from the `package.json` file.
    *
-   * @param context The {@link WorkspaceContext}.
    * @returns The currently installed dependencies in the Causa folder, or an empty object if the package file cannot be
    *   read.
    */
-  private async readCurrentDependencies(
-    context: WorkspaceContext,
-  ): Promise<Record<string, string>> {
+  private async readCurrentDependencies(): Promise<Record<string, string>> {
     try {
-      const causaDir = join(context.rootPath, CAUSA_FOLDER);
+      const causaDir = join(this._context.rootPath, CAUSA_FOLDER);
       const packageFile = join(causaDir, 'package.json');
       const packageJson = await readFile(packageFile);
       return JSON.parse(packageJson.toString()).dependencies;
     } catch (error) {
-      context.logger.warn(
+      this._context.logger.warn(
         `⚠️ Could not read the currently installed dependencies from the Causa folder: '${error}'.`,
       );
 

--- a/src/functions/project/publish-artefact.ts
+++ b/src/functions/project/publish-artefact.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import {
   ProjectBuildArtefact,
   ProjectGetArtefactDestination,
@@ -18,29 +17,29 @@ import { GitService } from '../../services/index.js';
  * - {@link ProjectPushArtefact}
  */
 export class ProjectPublishArtefactForAll extends ProjectPublishArtefact {
-  async _call(context: WorkspaceContext): Promise<string> {
+  async _call(): Promise<string> {
     const artefact =
-      this.artefact ?? (await context.call(ProjectBuildArtefact, {}));
+      this.artefact ?? (await this._context.call(ProjectBuildArtefact, {}));
 
     let tag = this.tag ?? ProjectPublishArtefact.TagFormatShortSha;
     switch (tag) {
       case ProjectPublishArtefact.TagFormatSemantic:
-        tag = await context.call(ProjectReadVersion, {});
+        tag = await this._context.call(ProjectReadVersion, {});
         break;
       case ProjectPublishArtefact.TagFormatShortSha:
-        const gitService = context.service(GitService);
-        tag = await gitService.getCurrentShortSha();
+        tag = await this._context.service(GitService).getCurrentShortSha();
         break;
     }
     if (this.tagPrefix) {
       tag = `${this.tagPrefix}${tag}`;
     }
 
-    const destination = await context.call(ProjectGetArtefactDestination, {
-      tag,
-    });
+    const destination = await this._context.call(
+      ProjectGetArtefactDestination,
+      { tag },
+    );
 
-    await context.call(ProjectPushArtefact, {
+    await this._context.call(ProjectPushArtefact, {
       artefact,
       destination,
       overwrite: this.overwrite,

--- a/src/functions/project/push-artefact-service-container.ts
+++ b/src/functions/project/push-artefact-service-container.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import {
   ArtefactAlreadyExistsError,
   ProjectPushArtefact,
@@ -15,8 +14,8 @@ import {
  * If {@link ProjectPushArtefact.overwrite} is not set to `true`, pushing an existing remote tag will fail.
  */
 export class ProjectPushArtefactForServiceContainer extends ProjectPushArtefact {
-  async _call(context: WorkspaceContext): Promise<string> {
-    const dockerService = context.service(DockerService);
+  async _call(): Promise<string> {
+    const dockerService = this._context.service(DockerService);
 
     const localTag = this.artefact;
     const remoteTag = this.destination;
@@ -30,7 +29,9 @@ export class ProjectPushArtefactForServiceContainer extends ProjectPushArtefact 
 
     await dockerService.tag(localTag, remoteTag);
 
-    context.logger.info(`🚚 Pushing Docker image to the remote registry.`);
+    this._context.logger.info(
+      `🚚 Pushing Docker image to the remote registry.`,
+    );
 
     try {
       await dockerService.push(remoteTag);
@@ -47,14 +48,14 @@ export class ProjectPushArtefactForServiceContainer extends ProjectPushArtefact 
       throw error;
     }
 
-    context.logger.info(
+    this._context.logger.info(
       `🚚 Successfully pushed Docker image to '${remoteTag}'.`,
     );
 
     return remoteTag;
   }
 
-  _supports(context: WorkspaceContext): boolean {
-    return context.get('project.type') === 'serviceContainer';
+  _supports(): boolean {
+    return this._context.get('project.type') === 'serviceContainer';
   }
 }

--- a/src/functions/project/write-configurations.ts
+++ b/src/functions/project/write-configurations.ts
@@ -1,8 +1,4 @@
-import {
-  type ProcessorResult,
-  WorkspaceContext,
-  WorkspaceFunction,
-} from '@causa/workspace';
+import { type ProcessorResult, WorkspaceFunction } from '@causa/workspace';
 import { CAUSA_FOLDER } from '@causa/workspace/initialization';
 import { AllowMissing } from '@causa/workspace/validation';
 import { IsBoolean } from 'class-validator';
@@ -35,47 +31,47 @@ export class ProjectWriteConfigurations
    * Returns the path to the directory where project configurations should be written.
    * It is either fetched from the workspace configuration, or the default value is used.
    *
-   * @param context The {@link WorkspaceContext}.
    * @returns The path to the directory where project configurations should be written.
    */
-  private getConfigurationsDirectory(context: WorkspaceContext): string {
+  private getConfigurationsDirectory(): string {
     return (
-      context
+      this._context
         .asConfiguration<CausaConfiguration>()
         .get('causa.projectConfigurationsDirectory') ??
       DEFAULT_PROJECT_CONFIGURATIONS_DIRECTORY
     );
   }
 
-  async _call(context: WorkspaceContext): Promise<ProcessorResult> {
-    const projectConfigurationsDirectory =
-      this.getConfigurationsDirectory(context);
+  async _call(): Promise<ProcessorResult> {
+    const projectConfigurationsDirectory = this.getConfigurationsDirectory();
     const absoluteDirectory = resolve(
-      context.rootPath,
+      this._context.rootPath,
       projectConfigurationsDirectory,
     );
     await rm(absoluteDirectory, { recursive: true, force: true });
 
     if (this.tearDown) {
-      context.logger.debug(
+      this._context.logger.debug(
         `🔧 Tore down project configurations directory '${absoluteDirectory}'.`,
       );
       return { configuration: {} };
     }
 
-    context.logger.info('🔧 Rendering and writing project configurations.');
+    this._context.logger.info(
+      '🔧 Rendering and writing project configurations.',
+    );
 
-    const projectPaths = await context.listProjectPaths();
+    const projectPaths = await this._context.listProjectPaths();
 
     await mkdir(absoluteDirectory, { recursive: true });
 
     await Promise.all(
       projectPaths.map(async (projectPath) => {
-        context.logger.debug(
+        this._context.logger.debug(
           `📂 Rendering configuration for project in directory '${projectPath}'.`,
         );
 
-        const projectContext = await context.clone({
+        const projectContext = await this._context.clone({
           workingDirectory: projectPath,
           // Processors are specific to a project (usually only loaded during specific operations of infrastructure
           // projects) and should not be copied.
@@ -92,7 +88,7 @@ export class ProjectWriteConfigurations
           `${projectName}.json`,
         );
 
-        context.logger.debug(
+        this._context.logger.debug(
           `📂 Writing configuration for project '${projectName}' to file '${configurationFile}'.`,
         );
         await writeFile(
@@ -102,7 +98,7 @@ export class ProjectWriteConfigurations
       }),
     );
 
-    context.logger.debug(
+    this._context.logger.debug(
       `🔧 Wrote project configurations in '${absoluteDirectory}'.`,
     );
 

--- a/src/functions/scenario/run.ts
+++ b/src/functions/scenario/run.ts
@@ -1,4 +1,3 @@
-import { WorkspaceContext } from '@causa/workspace';
 import { expect } from 'expect';
 import { readFile, writeFile } from 'fs/promises';
 import { dump, load } from 'js-yaml';
@@ -33,10 +32,10 @@ class RetryAttemptsExhaustedError extends Error {
  * executes the scenario's steps in dependency order, running independent steps in parallel.
  */
 export class ScenarioRunForAll extends ScenarioRun {
-  async _call(context: WorkspaceContext): Promise<ScenarioRunSnapshot> {
-    const filePath = resolve(context.rootPath, this.path);
+  async _call(): Promise<ScenarioRunSnapshot> {
+    const filePath = resolve(this._context.rootPath, this.path);
 
-    context.logger.info(`▶️ Running scenario from '${filePath}'.`);
+    this._context.logger.info(`▶️ Running scenario from '${filePath}'.`);
 
     const raw = await readFile(filePath, 'utf-8');
     const scenario = load(raw) as Scenario;
@@ -47,7 +46,7 @@ export class ScenarioRunForAll extends ScenarioRun {
       await Promise.all(
         [...allConfigPaths].map(
           async (path) =>
-            [path, await context.getAndRenderOrThrow(path)] as const,
+            [path, await this._context.getAndRenderOrThrow(path)] as const,
         ),
       ),
     );
@@ -69,7 +68,6 @@ export class ScenarioRunForAll extends ScenarioRun {
     };
 
     const result = await this.runSteps(
-      context,
       scenario,
       stepDeps,
       renderContext,
@@ -77,9 +75,9 @@ export class ScenarioRunForAll extends ScenarioRun {
     );
 
     if (this.output) {
-      const outputPath = resolve(context.rootPath, this.output);
+      const outputPath = resolve(this._context.rootPath, this.output);
       await writeFile(outputPath, dump(result));
-      context.logger.info(`📝 Wrote scenario result to '${outputPath}'.`);
+      this._context.logger.info(`📝 Wrote scenario result to '${outputPath}'.`);
     }
 
     if (result.status === 'failed') {
@@ -93,7 +91,6 @@ export class ScenarioRunForAll extends ScenarioRun {
    * Schedules and runs the scenario's steps in dependency order, running independent steps in parallel. Emits a
    * snapshot through {@link ScenarioRun.onStepUpdate} on every step transition.
    *
-   * @param context The workspace context to forward to step calls.
    * @param scenario The scenario whose steps should be executed.
    * @param stepDeps For each step, the set of other steps it depends on.
    * @param renderContext The render context used to evaluate step arguments and expectations.
@@ -101,7 +98,6 @@ export class ScenarioRunForAll extends ScenarioRun {
    * @returns The final {@link ScenarioRunSnapshot}.
    */
   private async runSteps(
-    context: WorkspaceContext,
     scenario: Scenario,
     stepDeps: Record<string, Set<string>>,
     renderContext: Record<string, any>,
@@ -141,7 +137,6 @@ export class ScenarioRunForAll extends ScenarioRun {
           const startedAt = new Date();
           updateStep(id, { status: 'running', startedAt, numRetries: 0 });
           const runPromise = this.runStep(
-            context,
             id,
             scenario,
             renderContext,
@@ -190,7 +185,6 @@ export class ScenarioRunForAll extends ScenarioRun {
   /**
    * Runs a single step with retry. Returns the final `succeeded` or `failed` {@link ScenarioStepRun}.
    *
-   * @param context The workspace context to use for the step call.
    * @param id The step ID.
    * @param scenario The scenario.
    * @param renderContext The global render context to use for rendering step arguments and expectations.
@@ -198,14 +192,13 @@ export class ScenarioRunForAll extends ScenarioRun {
    * @returns The final `succeeded` or `failed` {@link ScenarioStepRun} for the step.
    */
   private async runStep(
-    context: WorkspaceContext,
     id: string,
     scenario: Scenario,
     renderContext: Record<string, any>,
     startedAt: Date,
   ): Promise<ScenarioStepRun> {
     const step = scenario.steps[id];
-    context.logger.info(
+    this._context.logger.info(
       `▶️ Starting step '${id}' (calling '${step.call.name}').`,
     );
 
@@ -220,7 +213,7 @@ export class ScenarioRunForAll extends ScenarioRun {
           const message =
             error instanceof Error ? error.message : String(error);
           const firstLine = message.split('\n')[0];
-          context.logger.warn(
+          this._context.logger.warn(
             `⚠️ Step '${id}' attempt ${attempt}/${maxAttempts} failed: ${firstLine}`,
           );
         },
@@ -233,7 +226,7 @@ export class ScenarioRunForAll extends ScenarioRun {
             },
             renderContext,
           );
-          output = await context.callByName(step.call.name, args);
+          output = await this._context.callByName(step.call.name, args);
           this.verifyStep(step, id, output, renderContext);
         },
       ));
@@ -253,11 +246,11 @@ export class ScenarioRunForAll extends ScenarioRun {
     const endedAt = new Date();
     const duration = endedAt.getTime() - startedAt.getTime();
     if (status === 'succeeded') {
-      context.logger.info(
+      this._context.logger.info(
         `✅ Step '${id}' finished in ${duration}ms (${attempt} attempt(s)).`,
       );
     } else {
-      context.logger.error(
+      this._context.logger.error(
         `❌ Step '${id}' failed after ${attempt} attempt(s) in ${duration}ms: ${error}`,
       );
     }


### PR DESCRIPTION
### 📝 Description of the PR

Adapts the module to the breaking changes in `@causa/workspace`: `_call` and `_supports` no longer receive a `context` argument, and implementations now access the workspace context through the `_context` property instead. Secondary methods that previously took a `context` argument have been updated to use `this._context` as well.

Also removes the `key` (ordering) property from `BackfillEvent`, alongside dependency upgrades and an ESLint configuration update.

To adapt, downstream implementations of workspace functions must drop the `context` parameter from their `_call` and `_supports` methods and access the context through `this._context`. Backfill event sources should no longer populate a `key` field on emitted events.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.