### PR TITLE
🔖 Prepare v0.35.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.0-beta.1 (2026-05-18)
+
 Breaking changes:
 
 - Remove the `key` (ordering) property from `BackfillEvent`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.34.0",
+  "version": "0.35.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.34.0",
+      "version": "0.35.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.34.0",
+  "version": "0.35.0-beta.1",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove the `key` (ordering) property from `BackfillEvent`.

Features:

- Define the format-neutral schema model types (`Schema`, `ObjectSchema`, `EnumSchema`, `UnionSchema`, `Property`, `PropertyType`, `SchemaDatabase`, `CausaExtensions`, `InvalidSchemaError`).
- Define the `ModelSchemaParse`, `ModelSchemaExtractDatabase`, and `ModelSchemaWrite` workspace functions.
- Implement `ModelSchemaParse` and `ModelSchemaWrite` for JSONSchema.

Chores:

- Replace the `js-yaml` dependency with `yaml`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~