### PR TITLE
🔖 Prepare v0.35.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.0-beta.2 (2026-05-21)
+
 Breaking changes:
 
 - Remove the `quicktype`-based code generation, including the `./code-generation` subpath export, the `MakeGeneratorQuicktypeInputData` workspace function, and the `quicktype-core` dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.1",
+  "version": "0.35.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.35.0-beta.1",
+      "version": "0.35.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.1",
+  "version": "0.35.0-beta.2",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove the `quicktype`-based code generation, including the `./code-generation` subpath export, the `MakeGeneratorQuicktypeInputData` workspace function, and the `quicktype-core` dependency.

Features:

- Export the `./jsonschema` subpath.

Chores:

- Remove the `axios` dependency in favor of the Node.js-provided `fetch`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~