### PR TITLE
✨ Define health check configuration for service containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `serviceContainer.healthCheck` configuration for service containers, with `startup` and `liveness` probe blocks supporting `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`.
+
 ## v0.35.0-beta.2 (2026-05-21)
 
 Breaking changes:

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -609,6 +609,77 @@ export class ServiceContainerEndpoints {
 }
 
 /**
+ * Configuration for an HTTP health check probe.
+ */
+export class ServiceContainerHealthCheckProbe {
+  constructor(init: ServiceContainerHealthCheckProbe) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * The number of consecutive failures after which the probe is considered failed.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly failureThreshold?: number;
+
+  /**
+   * The number of seconds after the container has started before the probe is first invoked.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly initialDelay?: number;
+
+  /**
+   * The HTTP path called by the probe. Defaults to `/health`.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly path?: string;
+
+  /**
+   * The period in seconds at which the probe is invoked.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly period?: number;
+
+  /**
+   * The number of seconds after which the probe times out.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly timeout?: number;
+  [property: string]: any;
+}
+
+/**
+ * Configuration for the HTTP health check probes of the service.
+ */
+export class ServiceContainerHealthCheck {
+  constructor(init: ServiceContainerHealthCheck) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * Configuration for the liveness probe.
+   * Setting this to `null` disables the liveness probe.
+   */
+  @IsNullable()
+  @AllowMissing()
+  readonly liveness?: null | ServiceContainerHealthCheckProbe;
+
+  /**
+   * Configuration for the startup probe.
+   * Setting this to `null` disables the startup probe.
+   */
+  @IsNullable()
+  @AllowMissing()
+  readonly startup?: null | ServiceContainerHealthCheckProbe;
+  [property: string]: any;
+}
+
+/**
  * The data this service produces.
  */
 export class ServiceContainerOutputs {
@@ -760,6 +831,14 @@ export class ServiceContainer {
   @AllowMissing()
   @IsObject()
   readonly environmentVariables?: { [key: string]: string };
+
+  /**
+   * Configuration for the HTTP health check probes of the service.
+   * Setting this to `null` disables both the startup and liveness probes.
+   */
+  @IsNullable()
+  @AllowMissing()
+  readonly healthCheck?: null | ServiceContainerHealthCheck;
 
   /**
    * The maximum number of instances of the service that should be running.

--- a/src/configurations/schemas/service-container.yaml
+++ b/src/configurations/schemas/service-container.yaml
@@ -196,6 +196,32 @@ properties:
                 - type
                 - queue
 
+      healthCheck:
+        description: |-
+          Configuration for the HTTP health check probes of the service.
+          Setting this to `null` disables both the startup and liveness probes.
+        oneOf:
+          - type: 'null'
+          - title: ServiceContainerHealthCheck
+            type: object
+            description: Configuration for the HTTP health check probes of the service.
+            properties:
+              startup:
+                description: |-
+                  Configuration for the startup probe.
+                  Setting this to `null` disables the startup probe.
+                oneOf:
+                  - type: 'null'
+                  - $ref: '#/$defs/ServiceContainerHealthCheckProbe'
+
+              liveness:
+                description: |-
+                  Configuration for the liveness probe.
+                  Setting this to `null` disables the liveness probe.
+                oneOf:
+                  - type: 'null'
+                  - $ref: '#/$defs/ServiceContainerHealthCheckProbe'
+
       outputs:
         title: ServiceContainerOutputs
         description: The data this service produces.
@@ -210,3 +236,28 @@ properties:
 $defs:
   _TemplateString:
     type: string
+
+  ServiceContainerHealthCheckProbe:
+    title: ServiceContainerHealthCheckProbe
+    type: object
+    description: Configuration for an HTTP health check probe.
+    properties:
+      path:
+        type: string
+        description: The HTTP path called by the probe. Defaults to `/health`.
+
+      initialDelay:
+        type: number
+        description: The number of seconds after the container has started before the probe is first invoked.
+
+      period:
+        type: number
+        description: The period in seconds at which the probe is invoked.
+
+      timeout:
+        type: number
+        description: The number of seconds after which the probe times out.
+
+      failureThreshold:
+        type: number
+        description: The number of consecutive failures after which the probe is considered failed.


### PR DESCRIPTION
### 📝 Description of the PR

Adds the `serviceContainer.healthCheck` configuration to the service container schema, with independent `startup` and `liveness` probe blocks supporting `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`. Setting `healthCheck`, `healthCheck.startup`, or `healthCheck.liveness` to `null` disables the corresponding probe(s). This matches the shape consumed by [`terraform-google-service-container-cloud-run` v0.24.0](https://github.com/causa-io/terraform-google-service-container-cloud-run), which replaced the `healthcheck_endpoint` variable with this configuration.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.