### PR TITLE
✨ Improve JSONSchema parsing with broader spec coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+Features:
+
+- Support inline object, enum, and union schemas declared inside a property's `oneOf` (including the nullable wrapper), inside array `items`, and inside `additionalProperties` during JSONSchema parsing.
+- Support `type` declared as an array (e.g. `[string, "null"]`, `[string, integer]`) during JSONSchema parsing, both as a nullable wrapper and as a shorthand for a union.
+- Infer a schema name from the source path (filename, `$defs`/`definitions` key, or property name) when no `title` is provided during JSONSchema parsing.
+
+Fixes:
+
+- Ignore unsupported JSONSchema `format` values for primitive types rather than throwing, falling back to the bare type.
+- Treat a missing `additionalProperties` as `true` (the JSONSchema default) when parsing maps, so that `{ type: object }` with no `properties` resolves to a map of any.
+
 ## v0.35.0-beta.3 (2026-05-21)
 
 Features:

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -320,6 +320,61 @@ $defs:
       });
     });
 
+    it('should extract a nullable inline object schema with the oneOf-suffixed pointer', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  address:
+    oneOf:
+      - title: Address
+        type: object
+        properties:
+          street:
+            type: string
+      - type: "null"`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/address/oneOf/0`;
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ path: inlinePointer });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: inlinePointer },
+        nullable: true,
+      });
+    });
+
+    it('should extract a nullable inline enum schema with the oneOf-suffixed pointer', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  status:
+    oneOf:
+      - type: "null"
+      - title: Status
+        type: string
+        enum: [active, archived]`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/status/oneOf/1`;
+      const inline = schemas.find((s) => s.name === 'Status');
+      expect(inline).toMatchObject({
+        kind: 'enum',
+        type: 'string',
+        values: ['active', 'archived'],
+        path: inlinePointer,
+      });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: inlinePointer },
+        nullable: true,
+      });
+    });
+
     it('should extract inline object schemas with their own path', () => {
       const schemas = parseJsonSchema(
         `

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -70,12 +70,6 @@ oneOf:
       );
     });
 
-    it('should throw when the title is missing', () => {
-      expect(() => parseJsonSchema('type: object', path)).toThrow(
-        /missing title/,
-      );
-    });
-
     it('should throw when a union has fewer than two non-null variants', () => {
       expect(() =>
         parseJsonSchema('title: Bad\noneOf:\n  - type: string', path),
@@ -398,6 +392,70 @@ properties:
         kind: 'ref',
         ref: `${path}#/properties/address`,
       });
+    });
+  });
+
+  describe('title fallbacks', () => {
+    it('should fall back to the filename without extension for the top-level schema', () => {
+      const [schema] = parseJsonSchema('type: object', path);
+
+      expect(schema).toMatchObject({ kind: 'object', name: 'file', path });
+    });
+
+    it('should fall back to the entry key for $defs schemas', () => {
+      const schemas = parseJsonSchema(
+        `
+type: object
+$defs:
+  Address:
+    type: object`,
+        path,
+      );
+
+      const address = schemas.find((s) => s.path === `${path}#/$defs/Address`);
+      expect(address).toMatchObject({ name: 'Address' });
+    });
+
+    it('should fall back to the property name for inline object schemas', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  address:
+    type: object
+    properties:
+      street:
+        type: string`,
+        path,
+      );
+
+      const inline = schemas.find(
+        (s) => s.path === `${path}#/properties/address`,
+      );
+      expect(inline).toMatchObject({ kind: 'object', name: 'address' });
+    });
+
+    it('should fall back to the property name for inline schemas nested in a nullable oneOf', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  address:
+    oneOf:
+      - type: object
+        properties:
+          street:
+            type: string
+      - type: "null"`,
+        path,
+      );
+
+      const inline = schemas.find(
+        (s) => s.path === `${path}#/properties/address/oneOf/0`,
+      );
+      expect(inline).toMatchObject({ kind: 'object', name: 'address' });
     });
   });
 

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -142,6 +142,24 @@ properties:
       });
     });
 
+    it('should ignore an unrecognized format and fall back to the bare type', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: U
+type: object
+properties:
+  email:
+    type: string
+    format: email`,
+        path,
+      );
+
+      expect((schema as any).properties[0].type).toEqual({
+        kind: 'primitive',
+        type: 'string',
+      });
+    });
+
     it('should resolve datetime format', () => {
       const [schema] = parseJsonSchema(
         `

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -567,6 +567,176 @@ properties:
       });
     });
 
+    it('should extract an inline object schema declared inside array items', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  addresses:
+    type: array
+    items:
+      title: Address
+      type: object
+      properties:
+        street:
+          type: string`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/addresses/items`;
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ kind: 'object', path: inlinePointer });
+      expect((schemas[0] as any).properties[0].type).toEqual({
+        kind: 'array',
+        items: { kind: 'ref', ref: inlinePointer },
+        itemNullable: false,
+      });
+    });
+
+    it('should extract a nullable inline object schema declared inside array items', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  addresses:
+    type: array
+    items:
+      type: [object, "null"]
+      title: Address
+      properties:
+        street:
+          type: string`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/addresses/items/oneOf/0`;
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ kind: 'object', path: inlinePointer });
+      expect((schemas[0] as any).properties[0].type).toEqual({
+        kind: 'array',
+        items: { kind: 'ref', ref: inlinePointer },
+        itemNullable: true,
+      });
+    });
+
+    it('should extract an inline enum schema declared inside array items', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  statuses:
+    type: array
+    items:
+      title: Status
+      type: string
+      enum: [active, archived]`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/statuses/items`;
+      const inline = schemas.find((s) => s.name === 'Status');
+      expect(inline).toMatchObject({
+        kind: 'enum',
+        type: 'string',
+        values: ['active', 'archived'],
+        path: inlinePointer,
+      });
+    });
+
+    it('should extract an inline union declared inside array items', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  values:
+    type: array
+    items:
+      title: Value
+      oneOf:
+        - type: string
+        - type: integer`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/values/items`;
+      const union = schemas.find((s) => s.name === 'Value');
+      expect(union).toMatchObject({ kind: 'union', path: inlinePointer });
+    });
+
+    it('should fall back to `${propertyName}Item` for an untitled inline schema in array items', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  addresses:
+    type: array
+    items:
+      type: object
+      properties:
+        street:
+          type: string`,
+        path,
+      );
+
+      const inline = schemas.find(
+        (s) => s.path === `${path}#/properties/addresses/items`,
+      );
+      expect(inline).toMatchObject({ kind: 'object', name: 'addressesItem' });
+    });
+
+    it('should extract an inline object schema declared inside additionalProperties', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  byId:
+    type: object
+    additionalProperties:
+      title: Entry
+      type: object
+      properties:
+        name:
+          type: string`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/byId/additionalProperties`;
+      const inline = schemas.find((s) => s.name === 'Entry');
+      expect(inline).toMatchObject({ kind: 'object', path: inlinePointer });
+      expect((schemas[0] as any).properties[0].type).toEqual({
+        kind: 'map',
+        items: { kind: 'ref', ref: inlinePointer },
+      });
+    });
+
+    it('should fall back to `${propertyName}Value` for an untitled inline schema in additionalProperties', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  byId:
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        name:
+          type: string`,
+        path,
+      );
+
+      const inline = schemas.find(
+        (s) => s.path === `${path}#/properties/byId/additionalProperties`,
+      );
+      expect(inline).toMatchObject({ kind: 'object', name: 'byIdValue' });
+    });
+
     it('should extract inline object schemas with their own path', () => {
       const schemas = parseJsonSchema(
         `

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -64,16 +64,47 @@ oneOf:
       });
     });
 
+    it('should parse a top-level union declared with an array `type`', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: Either
+type: [string, integer]
+description: A scalar.`,
+        path,
+      );
+
+      expect(schema).toMatchObject({
+        kind: 'union',
+        name: 'Either',
+        description: 'A scalar.',
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      });
+    });
+
     it('should throw when the document is not an object', () => {
       expect(() => parseJsonSchema('- not an object', path)).toThrow(
         /document is not an object/,
       );
     });
 
-    it('should throw when a union has fewer than two non-null variants', () => {
-      expect(() =>
-        parseJsonSchema('title: Bad\noneOf:\n  - type: string', path),
-      ).toThrow(/at least two non-null variants/);
+    it('should parse a top-level nullable union with a single non-null variant', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: Maybe
+oneOf:
+  - type: string
+  - type: "null"`,
+        path,
+      );
+
+      expect(schema).toMatchObject({
+        kind: 'union',
+        name: 'Maybe',
+        types: [{ kind: 'primitive', type: 'string' }, { kind: 'null' }],
+      });
     });
   });
 
@@ -148,7 +179,47 @@ properties:
       });
     });
 
-    it('should reject oneOf without exactly one non-null variant', () => {
+    it('should mark a property nullable via an array `type` with a null entry', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: U
+type: object
+properties:
+  name:
+    type: [string, "null"]`,
+        path,
+      );
+
+      expect((schema as any).properties[0]).toMatchObject({
+        type: { kind: 'primitive', type: 'string' },
+        nullable: true,
+      });
+    });
+
+    it('should extract an inline object schema declared with an array `type`', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  address:
+    type: [object, "null"]
+    title: Address
+    properties:
+      street:
+        type: string`,
+        path,
+      );
+
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ kind: 'object' });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: (inline as any).path },
+        nullable: true,
+      });
+    });
+
+    it('should reject combining an array `type` with `oneOf`', () => {
       expect(() =>
         parseJsonSchema(
           `
@@ -156,12 +227,13 @@ title: U
 type: object
 properties:
   name:
+    type: [string, "null"]
     oneOf:
       - type: string
-      - type: integer`,
+      - type: "null"`,
           path,
         ),
-      ).toThrow(/exactly one non-null variant/);
+      ).toThrow(/cannot combine an array .type. with .oneOf./);
     });
 
     it('should parse array with nullable items', () => {
@@ -176,6 +248,26 @@ properties:
       oneOf:
         - type: string
         - type: "null"`,
+        path,
+      );
+
+      expect((schema as any).properties[0].type).toEqual({
+        kind: 'array',
+        items: { kind: 'primitive', type: 'string' },
+        itemNullable: true,
+      });
+    });
+
+    it('should parse array items declared with a nullable array `type`', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: U
+type: object
+properties:
+  tags:
+    type: array
+    items:
+      type: [string, "null"]`,
         path,
       );
 
@@ -311,6 +403,94 @@ $defs:
       const address = schemas.find((s) => s.name === 'Address');
       expect(address).toMatchObject({
         path: `${path}#/$defs/Address`,
+      });
+    });
+
+    it('should extract an inline union declared with oneOf on a property', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  value:
+    title: Value
+    oneOf:
+      - type: string
+      - type: integer`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/value`;
+      const union = schemas.find((s) => s.name === 'Value');
+      expect(union).toMatchObject({
+        kind: 'union',
+        path: inlinePointer,
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: inlinePointer },
+        nullable: false,
+      });
+    });
+
+    it('should extract a inline union with null', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  value:
+    oneOf:
+      - type: string
+      - type: integer
+      - type: "null"`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/value`;
+      const union = schemas.find((s) => s.path === inlinePointer);
+      expect(union).toMatchObject({
+        kind: 'union',
+        name: 'value',
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+          { kind: 'null' },
+        ],
+      });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: inlinePointer },
+        nullable: false,
+      });
+    });
+
+    it('should extract an inline union declared with an array `type` on a property', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  value:
+    type: [string, integer]`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/value`;
+      const union = schemas.find((s) => s.path === inlinePointer);
+      expect(union).toMatchObject({
+        kind: 'union',
+        name: 'value',
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: inlinePointer },
+        nullable: false,
       });
     });
 

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -315,6 +315,23 @@ properties:
       });
     });
 
+    it('should treat type: object with no properties and no additionalProperties as a map of any', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: U
+type: object
+properties:
+  bag:
+    type: object`,
+        path,
+      );
+
+      expect((schema as any).properties[0].type).toEqual({
+        kind: 'map',
+        items: 'any',
+      });
+    });
+
     it('should parse a map with any values when additionalProperties is true', () => {
       const [schema] = parseJsonSchema(
         `

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -545,7 +545,7 @@ function resolveMapType(prop: CausaSchema, path: string): PropertyType {
  * @param format The raw JSON Schema `format` value, if any.
  * @param path Absolute path of the containing file, used for error reporting.
  * @returns The resolved primitive type.
- * @throws {InvalidSchemaError} When the type/format combination is missing, unrecognized, or inconsistent.
+ * @throws {InvalidSchemaError} When `type` is missing or not a recognized primitive.
  */
 function resolvePrimitiveType(
   rawType: string | undefined,
@@ -558,7 +558,7 @@ function resolvePrimitiveType(
   if (rawType === 'string' && format === 'uuid') {
     return { kind: 'primitive', type: 'uuid' };
   }
-  if (!format && rawType && PRIMITIVE_TYPES.has(rawType as PrimitiveType)) {
+  if (rawType && PRIMITIVE_TYPES.has(rawType as PrimitiveType)) {
     return { kind: 'primitive', type: rawType as PrimitiveType };
   }
   throw new InvalidSchemaError(

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -105,7 +105,7 @@ function defaultSchemaName(path: string): string {
 /**
  * Build one or more {@link Schema} entries from a recognized node shape.
  *
- * @param schema The source schema node.
+ * @param rawSchema The source schema node.
  * @param name Display name for the produced schema.
  * @param path Full path identifying the produced schema.
  * @returns The produced schema followed by any inline schemas extracted from its properties (object case only).
@@ -113,10 +113,11 @@ function defaultSchemaName(path: string): string {
  *   `type: object`.
  */
 function parseSchemaBody(
-  schema: CausaSchema,
+  rawSchema: CausaSchema,
   name: string,
   path: string,
 ): Schema[] {
+  const schema = expandTypeArray(rawSchema, path);
   const description = schema.description;
   const extensions = buildExtensions(schema.causa, path);
 
@@ -138,26 +139,11 @@ function parseSchemaBody(
   }
 
   if (schema.oneOf) {
-    const types = schema.oneOf.filter(
-      (o): o is JSONSchema7 => typeof o === 'object' && o.type !== 'null',
-    );
-    if (types.length < 2) {
-      throw new InvalidSchemaError(
-        path,
-        'a union must have at least two non-null variants',
-      );
-    }
+    const types = schema.oneOf
+      .filter((t): t is JSONSchema7 => typeof t === 'object')
+      .map((t) => resolveInnerType(t, path));
 
-    return [
-      {
-        kind: 'union',
-        name,
-        path,
-        description,
-        types: types.map((v) => resolveInnerType(v, path)),
-        extensions,
-      },
-    ];
+    return [{ kind: 'union', name, path, description, types, extensions }];
   }
 
   if (schema.type !== 'object') {
@@ -274,7 +260,11 @@ function tryResolveInlineSchema(
 ): { type: PropertyType; nested: Schema[] } | null {
   const isEnum = Array.isArray(prop.enum);
   const isObject = prop.type === 'object' && prop.properties !== undefined;
-  if (!isEnum && !isObject) {
+  const isUnion =
+    Array.isArray(prop.oneOf) &&
+    prop.oneOf.filter((v) => typeof v === 'object' && v.type !== 'null')
+      .length >= 2;
+  if (!isEnum && !isObject && !isUnion) {
     return null;
   }
 
@@ -287,60 +277,87 @@ function tryResolveInlineSchema(
 }
 
 /**
- * Unwrap a property's optional nullable `oneOf` wrapper, yielding the inner schema, its nullability, and the JSON
- * Pointer addressing the inner variant.
+ * Unwrap a property's `oneOf` (or array `type`) into the inner schema that drives type resolution, plus the property's
+ * nullability and the JSON Pointer addressing the inner schema.
  *
- * When `prop.oneOf` is absent, `prop` itself is returned as the inner schema. When present, the `oneOf` must consist
- * of exactly one non-null variant plus at most one `{ type: 'null' }` variant; the pointer is suffixed with
- * `"/oneOf/<index>"` to address the non-null variant.
+ * Behavior by `oneOf` shape (after array-`type` normalization):
+ * - Absent: the prop itself is returned, `nullable` false.
+ * - Exactly one non-null variant: that variant becomes the inner schema; `nullable` reflects the presence of a `null`
+ *   variant; the pointer is suffixed with `"/oneOf/<index>"`.
+ * - Two or more non-null variants: the prop itself is returned (will be recognized as an inline union by the caller);
+ *   `nullable` is false because the `null` variant, if any, belongs to the union schema rather than to the property.
+ * - Only `null` variants: the inner schema is `{ type: 'null' }`, `nullable` false.
  *
  * @param prop Raw property schema.
  * @param pointer JSON Pointer addressing the property itself.
  * @param path Absolute path of the containing file, used for error reporting.
  * @returns The inner schema, its nullability, and the pointer addressing it.
- * @throws {InvalidSchemaError} When `oneOf` is present but does not have exactly one non-null variant, or has more
- *   than one null variant.
  */
 function unwrapNullableOneOf(
   prop: CausaSchema,
   pointer: string,
   path: string,
 ): { inner: CausaSchema; nullable: boolean; pointer: string } {
-  const oneOf = prop.oneOf as CausaSchema[] | undefined;
+  const normalized = expandTypeArray(prop, path);
+  const oneOf = normalized.oneOf as CausaSchema[] | undefined;
   if (!oneOf) {
-    return { inner: prop, nullable: false, pointer };
+    return { inner: normalized, nullable: false, pointer };
   }
 
-  let nullCount = 0;
-  let nonNullIndex = -1;
-  let hasExtraNonNull = false;
-  oneOf.forEach((variant, i) => {
-    if (variant.type === 'null') {
-      nullCount++;
-    } else if (nonNullIndex === -1) {
-      nonNullIndex = i;
-    } else {
-      hasExtraNonNull = true;
-    }
-  });
+  const nullable = oneOf.some((v) => v.type === 'null');
+  const nonNullIndices = oneOf.flatMap((v, i) =>
+    v.type === 'null' ? [] : [i],
+  );
 
-  if (nullCount > 1) {
+  if (nonNullIndices.length === 0) {
+    return { inner: { type: 'null' }, nullable: false, pointer };
+  }
+
+  if (nonNullIndices.length === 1) {
+    const idx = nonNullIndices[0];
+    return { inner: oneOf[idx], nullable, pointer: `${pointer}/oneOf/${idx}` };
+  }
+
+  return { inner: normalized, nullable: false, pointer };
+}
+
+/**
+ * Rewrite a schema node that declares `type` as an array into an equivalent `oneOf` form, leaving other shapes
+ * unchanged.
+ *
+ * Each entry in the source `type` array becomes a `oneOf` variant carrying that single type. The non-`null` variants
+ * also inherit the rest of the original node's fields (e.g. `properties`, `items`, `format`, `title`), so that
+ * downstream nullable-unwrapping and inline-schema detection apply unchanged.
+ *
+ * Validation of how many `null`/non-`null` entries are present is left to the consuming `oneOf` logic.
+ *
+ * @param prop Raw schema node.
+ * @param path Absolute path of the containing file, used for error reporting.
+ * @returns The normalized schema node.
+ * @throws {InvalidSchemaError} When both `type` (as an array) and `oneOf` are declared on the same node.
+ */
+function expandTypeArray(prop: CausaSchema, path: string): CausaSchema {
+  if (!Array.isArray(prop.type)) {
+    return prop;
+  }
+  if (prop.oneOf !== undefined) {
     throw new InvalidSchemaError(
       path,
-      'oneOf may contain at most one null variant',
-    );
-  }
-  if (nonNullIndex === -1 || hasExtraNonNull) {
-    throw new InvalidSchemaError(
-      path,
-      'oneOf must have exactly one non-null variant',
+      'cannot combine an array `type` with `oneOf`',
     );
   }
 
+  const { type, ...rest } = prop;
+  const oneOf: CausaSchema[] = type.map((type) => ({
+    type,
+    ...(type !== 'null' ? rest : {}),
+  }));
+  const { title, description, causa } = rest;
   return {
-    inner: oneOf[nonNullIndex],
-    nullable: nullCount === 1,
-    pointer: `${pointer}/oneOf/${nonNullIndex}`,
+    oneOf,
+    ...(title !== undefined && { title }),
+    ...(description !== undefined && { description }),
+    ...(causa !== undefined && { causa }),
   };
 }
 
@@ -455,7 +472,7 @@ function resolveArrayType(prop: CausaSchema, path: string): PropertyType {
     throw new InvalidSchemaError(path, 'array must declare an items schema');
   }
 
-  const rawItems = prop.items as CausaSchema;
+  const rawItems = expandTypeArray(prop.items as CausaSchema, path);
   const itemOneOf = rawItems.oneOf as CausaSchema[] | undefined;
   if (itemOneOf) {
     const nonNull = itemOneOf.filter((o) => o.type !== 'null');

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -201,13 +201,19 @@ function parseProperties(
     const extensions = buildExtensions(prop.causa, path);
     const required = requiredSet.has(name);
     const { description } = prop;
-    const inline = tryResolveInlineSchema(prop, `${pointerPrefix}/${name}`);
+    const { inner, nullable, pointer } = unwrapNullableOneOf(
+      prop,
+      `${pointerPrefix}/${name}`,
+      path,
+    );
+
+    const inline = tryResolveInlineSchema(inner, pointer);
     if (inline) {
       nested.push(...inline.nested);
       properties.push({
         name,
         type: inline.type,
-        nullable: false,
+        nullable,
         required,
         description,
         extensions,
@@ -215,7 +221,7 @@ function parseProperties(
       continue;
     }
 
-    const { type, nullable } = resolvePropertyType(prop, path);
+    const type = resolveInnerType(inner, path);
     properties.push({
       name,
       type,
@@ -262,30 +268,50 @@ function tryResolveInlineSchema(
 }
 
 /**
- * Resolve a property's outer shape into a {@link PropertyType} plus a nullability flag.
+ * Unwrap a property's optional nullable `oneOf` wrapper, yielding the inner schema, its nullability, and the JSON
+ * Pointer addressing the inner variant.
+ *
+ * When `prop.oneOf` is absent, `prop` itself is returned as the inner schema. When present, the `oneOf` must consist
+ * of exactly one non-null variant plus at most one `{ type: 'null' }` variant; the pointer is suffixed with
+ * `"/oneOf/<index>"` to address the non-null variant.
  *
  * @param prop Raw property schema.
- * @param path Absolute path of the containing file.
- * @returns The resolved type and whether `null` is an accepted value.
+ * @param pointer JSON Pointer addressing the property itself.
+ * @param path Absolute path of the containing file, used for error reporting.
+ * @returns The inner schema, its nullability, and the pointer addressing it.
+ * @throws {InvalidSchemaError} When `oneOf` is present but does not have exactly one non-null variant, or has more
+ *   than one null variant.
  */
-function resolvePropertyType(
+function unwrapNullableOneOf(
   prop: CausaSchema,
+  pointer: string,
   path: string,
-): Pick<Property, 'type' | 'nullable'> {
+): { inner: CausaSchema; nullable: boolean; pointer: string } {
   const oneOf = prop.oneOf as CausaSchema[] | undefined;
   if (!oneOf) {
-    return { type: resolveInnerType(prop, path), nullable: false };
+    return { inner: prop, nullable: false, pointer };
   }
 
-  const nullVariants = oneOf.filter((o) => o.type === 'null');
-  const nonNullVariants = oneOf.filter((o) => o.type !== 'null');
-  if (nullVariants.length > 1) {
+  let nullCount = 0;
+  let nonNullIndex = -1;
+  let hasExtraNonNull = false;
+  oneOf.forEach((variant, i) => {
+    if (variant.type === 'null') {
+      nullCount++;
+    } else if (nonNullIndex === -1) {
+      nonNullIndex = i;
+    } else {
+      hasExtraNonNull = true;
+    }
+  });
+
+  if (nullCount > 1) {
     throw new InvalidSchemaError(
       path,
       'oneOf may contain at most one null variant',
     );
   }
-  if (nonNullVariants.length !== 1) {
+  if (nonNullIndex === -1 || hasExtraNonNull) {
     throw new InvalidSchemaError(
       path,
       'oneOf must have exactly one non-null variant',
@@ -293,8 +319,9 @@ function resolvePropertyType(
   }
 
   return {
-    type: resolveInnerType(nonNullVariants[0], path),
-    nullable: nullVariants.length === 1,
+    inner: oneOf[nonNullIndex],
+    nullable: nullCount === 1,
+    pointer: `${pointer}/oneOf/${nonNullIndex}`,
   };
 }
 

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema7 } from 'json-schema';
-import { dirname, join, normalize } from 'node:path';
+import { basename, dirname, extname, join, normalize } from 'node:path';
 import * as yaml from 'yaml';
 import {
   InvalidSchemaError,
@@ -74,12 +74,32 @@ function parseSchema(rawSchema: unknown, path: string): Schema[] {
   }
 
   const schema = rawSchema as CausaSchema;
-  const name = schema.title;
+  const name = schema.title ?? defaultSchemaName(path);
   if (!name) {
     throw new InvalidSchemaError(path, 'missing title');
   }
 
   return parseSchemaBody(schema, name, path);
+}
+
+/**
+ * Derive a default schema name from a schema's path.
+ *
+ * - When the path is a plain file path (`/abs/file.yaml`), the basename without extension is returned (`file`).
+ * - When the path carries a JSON Pointer fragment (`/abs/file.yaml#/$defs/Foo`), the last fragment segment is
+ *   returned (`Foo`).
+ *
+ * @param path Absolute path identifying the schema (with or without a fragment).
+ * @returns The fallback name, or an empty string when nothing usable can be derived.
+ */
+function defaultSchemaName(path: string): string {
+  const [filePath, fragment] = path.split('#', 2);
+  if (fragment !== undefined) {
+    return fragment.split('/').filter(Boolean).pop() ?? '';
+  }
+  const base = basename(filePath);
+  const ext = extname(base);
+  return ext ? base.slice(0, -ext.length) : base;
 }
 
 /**
@@ -207,7 +227,7 @@ function parseProperties(
       path,
     );
 
-    const inline = tryResolveInlineSchema(inner, pointer);
+    const inline = tryResolveInlineSchema(inner, pointer, name);
     if (inline) {
       nested.push(...inline.nested);
       properties.push({
@@ -244,11 +264,13 @@ function parseProperties(
  *
  * @param prop Raw property schema.
  * @param pointer JSON Pointer that will identify the inline schema, e.g. `"/abs/file.yaml#/properties/address"`.
+ * @param fallbackName Name to use when the inline schema does not declare a `title` (typically the property name).
  * @returns The resolved type and extracted nested schemas, or `null` to fall through.
  */
 function tryResolveInlineSchema(
   prop: CausaSchema,
   pointer: string,
+  fallbackName: string,
 ): { type: PropertyType; nested: Schema[] } | null {
   const isEnum = Array.isArray(prop.enum);
   const isObject = prop.type === 'object' && prop.properties !== undefined;
@@ -256,10 +278,7 @@ function tryResolveInlineSchema(
     return null;
   }
 
-  const name = prop.title;
-  if (!name) {
-    throw new InvalidSchemaError(pointer, 'missing title');
-  }
+  const name = prop.title ?? fallbackName;
 
   return {
     type: { kind: 'ref', ref: pointer },

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -429,7 +429,13 @@ function resolveInnerType(
     return resolveArrayType(prop, path, inline);
   }
 
-  if (rawType === 'object' && prop.additionalProperties !== undefined) {
+  if (rawType === 'object') {
+    if (prop.properties !== undefined) {
+      throw new InvalidSchemaError(
+        path,
+        'inline object schemas with `properties` are not supported here',
+      );
+    }
     return resolveMapType(prop, path, inline);
   }
 
@@ -538,8 +544,9 @@ function resolveArrayType(
 /**
  * Resolve a `type: object` schema node carrying `additionalProperties` into a {@link PropertyType} of kind `map`.
  *
- * The value type is `'any'` when `additionalProperties` is the boolean `true`, or the resolved inner type when it is
- * a schema. Any other shape throws. When an {@link InlineContext} is provided, inline object/enum/union shapes
+ * The value type is `'any'` when `additionalProperties` is absent (JSON Schema default) or the boolean `true`, or
+ * the resolved inner type when it is a schema. Any other shape throws. When an {@link InlineContext} is provided,
+ * inline object/enum/union shapes
  * declared directly as the value schema are extracted as nested {@link Schema} entries; their pointer is
  * `${inline.pointer}/additionalProperties` and their fallback name is `${inline.fallbackName}Value`.
  *
@@ -556,7 +563,7 @@ function resolveMapType(
   inline?: InlineContext,
 ): PropertyType {
   const additional = prop.additionalProperties;
-  if (additional === true) {
+  if (additional === undefined || additional === true) {
     return { kind: 'map', items: 'any' };
   }
 

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -19,6 +19,34 @@ import {
 type CausaSchema = JSONSchema7 & { causa?: Record<string, unknown> };
 
 /**
+ * Context threaded through type resolution to enable extraction of inline schemas (objects, enums, unions) declared
+ * directly inside `items`, `additionalProperties`, or as the property's own type.
+ *
+ * When this context is provided, {@link resolveInnerType} runs inline detection before its normal type-handling
+ * branches; any inline schemas it finds are appended to {@link InlineContext.schemas}, and the returned
+ * {@link PropertyType} is a `ref` pointing at the inline schema's pointer.
+ *
+ * `pointer` is the JSON Pointer addressing the current node; `fallbackName` is used as the schema name when the inline
+ * schema does not declare its own `title`.
+ */
+type InlineContext = {
+  /**
+   * List of inline schemas extracted so far, to which new entries are appended when discovered.
+   */
+  schemas: Schema[];
+
+  /**
+   * JSON Pointer addressing the current node, used to build the ref for any inline schema discovered at this node.
+   */
+  pointer: string;
+
+  /**
+   * Fallback name to use for any inline schema discovered at this node.
+   */
+  fallbackName: string;
+};
+
+/**
  * Set of primitive type names recognized by the model.
  */
 const PRIMITIVE_TYPES = new Set<PrimitiveType>([
@@ -213,21 +241,11 @@ function parseProperties(
       path,
     );
 
-    const inline = tryResolveInlineSchema(inner, pointer, name);
-    if (inline) {
-      nested.push(...inline.nested);
-      properties.push({
-        name,
-        type: inline.type,
-        nullable,
-        required,
-        description,
-        extensions,
-      });
-      continue;
-    }
-
-    const type = resolveInnerType(inner, path);
+    const type = resolveInnerType(inner, path, {
+      schemas: nested,
+      pointer,
+      fallbackName: name,
+    });
     properties.push({
       name,
       type,
@@ -366,9 +384,27 @@ function expandTypeArray(prop: CausaSchema, path: string): CausaSchema {
  *
  * @param prop Raw schema node.
  * @param path Absolute path of the containing file.
+ * @param inline Optional context enabling inline-schema extraction. When provided, inline objects/enums/unions become
+ *   nested {@link Schema} entries pushed onto {@link InlineContext.schemas} and a `ref` is returned in their place.
  * @returns The resolved type.
  */
-function resolveInnerType(prop: CausaSchema, path: string): PropertyType {
+function resolveInnerType(
+  prop: CausaSchema,
+  path: string,
+  inline?: InlineContext,
+): PropertyType {
+  if (inline) {
+    const matched = tryResolveInlineSchema(
+      prop,
+      inline.pointer,
+      inline.fallbackName,
+    );
+    if (matched) {
+      inline.schemas.push(...matched.nested);
+      return matched.type;
+    }
+  }
+
   if (typeof prop.$ref === 'string') {
     return { kind: 'ref', ref: resolveRef(prop.$ref, path) };
   }
@@ -390,11 +426,11 @@ function resolveInnerType(prop: CausaSchema, path: string): PropertyType {
   }
 
   if (rawType === 'array') {
-    return resolveArrayType(prop, path);
+    return resolveArrayType(prop, path, inline);
   }
 
   if (rawType === 'object' && prop.additionalProperties !== undefined) {
-    return resolveMapType(prop, path);
+    return resolveMapType(prop, path, inline);
   }
 
   return resolvePrimitiveType(rawType, prop.format, path);
@@ -457,13 +493,19 @@ function resolveConstType(prop: CausaSchema, path: string): PropertyType {
 /**
  * Resolve an `array`-typed schema node into a {@link PropertyType} of kind `array`.
  *
- * Item types may themselves use the nullable `oneOf: [..., {type: null}]` pattern.
+ * Item types may themselves use the nullable `oneOf: [..., {type: null}]` pattern, or carry inline object/enum/union
+ * shapes when an {@link InlineContext} is threaded in.
  *
  * @param prop Raw schema node with `type: 'array'`.
  * @param path Absolute path of the containing file.
+ * @param inline Optional context propagated to the items so inline schemas declared inside `items` can be extracted.
  * @returns The resolved array type.
  */
-function resolveArrayType(prop: CausaSchema, path: string): PropertyType {
+function resolveArrayType(
+  prop: CausaSchema,
+  path: string,
+  inline?: InlineContext,
+): PropertyType {
   if (
     !prop.items ||
     typeof prop.items !== 'object' ||
@@ -472,28 +514,24 @@ function resolveArrayType(prop: CausaSchema, path: string): PropertyType {
     throw new InvalidSchemaError(path, 'array must declare an items schema');
   }
 
-  const rawItems = expandTypeArray(prop.items as CausaSchema, path);
-  const itemOneOf = rawItems.oneOf as CausaSchema[] | undefined;
-  if (itemOneOf) {
-    const nonNull = itemOneOf.filter((o) => o.type !== 'null');
-    if (nonNull.length !== 1) {
-      throw new InvalidSchemaError(
-        path,
-        'array items oneOf must have exactly one non-null variant',
-      );
-    }
-
-    return {
-      kind: 'array',
-      items: resolveInnerType(nonNull[0], path),
-      itemNullable: itemOneOf.some((o) => o.type === 'null'),
-    };
-  }
+  const itemsPointer = inline ? `${inline.pointer}/items` : '';
+  const {
+    inner,
+    nullable: itemNullable,
+    pointer,
+  } = unwrapNullableOneOf(prop.items as CausaSchema, itemsPointer, path);
+  const itemInline = inline
+    ? {
+        schemas: inline.schemas,
+        pointer,
+        fallbackName: `${inline.fallbackName}Item`,
+      }
+    : undefined;
 
   return {
     kind: 'array',
-    items: resolveInnerType(rawItems, path),
-    itemNullable: false,
+    items: resolveInnerType(inner, path, itemInline),
+    itemNullable,
   };
 }
 
@@ -501,14 +539,22 @@ function resolveArrayType(prop: CausaSchema, path: string): PropertyType {
  * Resolve a `type: object` schema node carrying `additionalProperties` into a {@link PropertyType} of kind `map`.
  *
  * The value type is `'any'` when `additionalProperties` is the boolean `true`, or the resolved inner type when it is
- * a schema. Any other shape throws.
+ * a schema. Any other shape throws. When an {@link InlineContext} is provided, inline object/enum/union shapes
+ * declared directly as the value schema are extracted as nested {@link Schema} entries; their pointer is
+ * `${inline.pointer}/additionalProperties` and their fallback name is `${inline.fallbackName}Value`.
  *
  * @param prop Raw schema node.
  * @param path Absolute path of the containing file.
+ * @param inline Optional context propagated to the value schema so inline schemas declared inside
+ *   `additionalProperties` can be extracted.
  * @returns The resolved map type.
  * @throws {InvalidSchemaError} When `additionalProperties` is `false` or any value other than `true` or a schema.
  */
-function resolveMapType(prop: CausaSchema, path: string): PropertyType {
+function resolveMapType(
+  prop: CausaSchema,
+  path: string,
+  inline?: InlineContext,
+): PropertyType {
   const additional = prop.additionalProperties;
   if (additional === true) {
     return { kind: 'map', items: 'any' };
@@ -532,9 +578,17 @@ function resolveMapType(prop: CausaSchema, path: string): PropertyType {
     );
   }
 
+  const valueInline = inline
+    ? {
+        schemas: inline.schemas,
+        pointer: `${inline.pointer}/additionalProperties`,
+        fallbackName: `${inline.fallbackName}Value`,
+      }
+    : undefined;
+
   return {
     kind: 'map',
-    items: resolveInnerType(additional as CausaSchema, path),
+    items: resolveInnerType(additional as CausaSchema, path, valueInline),
   };
 }
 


### PR DESCRIPTION
### 📝 Description of the PR

Extends the JSONSchema parser to handle several common forms it previously rejected, bringing behavior closer to the JSONSchema specification and making schemas more ergonomic to write:

- Inline object, enum, and union schemas can now be declared directly inside a property's `oneOf` (including the nullable wrapper), inside array `items`, and inside `additionalProperties`. Each inline schema is extracted as its own `Schema` entry with a JSON Pointer addressing its source location.
- `type` can be declared as an array — both as a nullable wrapper (e.g. `[string, "null"]`) and as a shorthand for a union (e.g. `[string, integer]`) — at the property level, in array items, and at the top level / `$defs`.
- A schema name is now inferred from the source path (filename, `$defs`/`definitions` key, or property name) when no `title` is provided.
- Unsupported `format` values on primitive types are now ignored (falling back to the bare type) instead of throwing.
- A missing `additionalProperties` is treated as `true` (the JSONSchema default), so `{ type: object }` with no `properties` resolves to a map of any.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.