### PR TITLE
🔖 Prepare v0.35.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.0-beta.4 (2026-05-22)
+
 Features:
 
 - Support inline object, enum, and union schemas declared inside a property's `oneOf` (including the nullable wrapper), inside array `items`, and inside `additionalProperties` during JSONSchema parsing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.3",
+  "version": "0.35.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.35.0-beta.3",
+      "version": "0.35.0-beta.4",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.3",
+  "version": "0.35.0-beta.4",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Features:

- Support inline object, enum, and union schemas declared inside a property's `oneOf` (including the nullable wrapper), inside array `items`, and inside `additionalProperties` during JSONSchema parsing.
- Support `type` declared as an array (e.g. `[string, "null"]`, `[string, integer]`) during JSONSchema parsing, both as a nullable wrapper and as a shorthand for a union.
- Infer a schema name from the source path (filename, `$defs`/`definitions` key, or property name) when no `title` is provided during JSONSchema parsing.

Fixes:

- Ignore unsupported JSONSchema `format` values for primitive types rather than throwing, falling back to the bare type.
- Treat a missing `additionalProperties` as `true` (the JSONSchema default) when parsing maps, so that `{ type: object }` with no `properties` resolves to a map of any.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~