### PR TITLE
✨ Auto-clean option for events backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- `cs events backfill` no longer writes a backfill file when no temporary resources were created (e.g. no temporary topic and no triggers, or when the command fails before any temporary resource exists). In that case, the command returns an empty string instead of a path, and its output is suppressed.
+
+Features:
+
+- Add the `--autoClean` option to `cs events backfill`, which waits for events to be processed after publishing and runs `cleanBackfill` inline. Introduces the broker-side `EventTopicBrokerWaitForProcessing` workspace function, which implementations should provide to support `--autoClean`.
+
 ## v0.35.0-beta.4 (2026-05-22)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Triggers passed with `--trigger` are free-form URIs by default and are interpret
 
 The events to publish are built by `EventTopicCreateBackfillSource`, which returns an `AsyncIterable<BackfillEvent>` passed to `EventTopicBrokerPublishEvents`. This module ships an implementation for `json://<glob>` sources (newline-delimited JSON files with `data`, optional `attributes`, and optional `key` fields). When no `--source` is passed, the broker module is expected to provide an implementation that yields from its default storage for the topic. Filtering, when supported, is applied inside the source implementation — the returned iterable yields only the events that should actually be published.
 
+Passing `--autoClean` to `cs events backfill` makes the command wait for events to be processed once publishing succeeds, then run the equivalent of `cs events cleanBackfill` inline — so a single call handles publish, drain, and cleanup. The wait is delegated to `EventTopicBrokerWaitForProcessing`, which is broker-specific (timeout and "processed" semantics live there). On success no backfill file is written and the command outputs nothing. On any failure during publish, wait, or cleanup, the backfill file is written so `cs events cleanBackfill` can still be run manually.
+
 ## 🎬 Scenarios
 
 Scenarios are YAML files that orchestrate calls to workspace functions, with templated arguments, dependency-driven scheduling, expectations, and retries. They are run with `cs scenario run <path>` (relative paths are resolved from the workspace root). The schema for a scenario file is shipped with this module at [`./src/scenarios/schemas/scenario.yaml`](./src/scenarios/schemas/scenario.yaml) and embedded under `dist/scenarios/schemas/` when published.

--- a/src/definitions/event-topic.ts
+++ b/src/definitions/event-topic.ts
@@ -181,7 +181,11 @@ Temporary triggers can be created for the backfill, and deleted afterwards using
 If no source is specified, the events are retrieved from the default storage for the broker. Optionally, a custom source might be used.
 Finally, some event sources might support filtering of the events to backfill.`,
   summary: 'Backfills events for an event topic.',
-  outputFn: (result) => console.log(result),
+  outputFn: (result) => {
+    if (result) {
+      console.log(result);
+    }
+  },
 })
 export abstract class EventTopicBackfill extends WorkspaceFunction<
   Promise<string>
@@ -262,6 +266,21 @@ export abstract class EventTopicBackfill extends WorkspaceFunction<
   @IsString()
   @AllowMissing()
   readonly output?: string;
+
+  /**
+   * Whether to wait for events to be processed after publishing, then clean up temporary resources inline.
+   * When set, after a successful publish the implementation calls {@link EventTopicBrokerWaitForProcessing}, then
+   * {@link EventTopicCleanBackfill}. On success no backfill file is written and the function returns an empty string.
+   * On any failure during wait or clean, the backfill file is written so that `cleanBackfill` can be run manually.
+   */
+  @CliOption({
+    flags: '--autoClean',
+    description:
+      'Wait for events to be processed after publishing and clean up temporary resources in the same command.',
+  })
+  @IsBoolean()
+  @AllowMissing()
+  readonly autoClean?: boolean;
 }
 
 /**
@@ -491,6 +510,30 @@ export abstract class EventTopicBrokerPublishEvents extends WorkspaceFunction<
   // and throws on async-generator instances. A function-typed value is passed through untouched.
   @IsInstance(Function)
   readonly source!: () => AsyncIterable<BackfillEvent>;
+}
+
+/**
+ * Waits for events published during a backfill to be processed by the triggers that received them.
+ * Called by {@link EventTopicBackfill} when `autoClean` is set, before invoking {@link EventTopicCleanBackfill}.
+ * The exact "processed" semantics, polling cadence, and timeout are decided by the broker-specific implementation.
+ * Should throw if processing cannot be confirmed (e.g. on timeout), so the backfill file is preserved for manual
+ * cleanup.
+ */
+export abstract class EventTopicBrokerWaitForProcessing extends WorkspaceFunction<
+  Promise<void>
+> {
+  /**
+   * The full event topic name (e.g. `my-domain.my-event.v1`) the events were published for.
+   */
+  @IsString()
+  readonly eventTopic!: string;
+
+  /**
+   * The temporary resources created during the backfill, as written to the backfill file.
+   * Implementations typically use {@link BackfillTemporaryData.temporaryTriggerResourceIds} to know which subscriptions
+   * to monitor, and {@link BackfillTemporaryData.temporaryTopicId} when set.
+   */
+  readonly temporaryData!: BackfillTemporaryData;
 }
 
 /**

--- a/src/functions/event-topic/backfill.spec.ts
+++ b/src/functions/event-topic/backfill.spec.ts
@@ -6,7 +6,7 @@ import {
   registerMockFunction,
 } from '@causa/workspace/testing';
 import { jest } from '@jest/globals';
-import { mkdtemp, readFile, rm } from 'fs/promises';
+import { access, mkdtemp, readFile, rm } from 'fs/promises';
 import 'jest-extended';
 import { join, resolve } from 'path';
 import {
@@ -16,6 +16,8 @@ import {
   EventTopicBrokerCreateTrigger,
   EventTopicBrokerGetTopicId,
   EventTopicBrokerPublishEvents,
+  EventTopicBrokerWaitForProcessing,
+  EventTopicCleanBackfill,
   EventTopicCreateBackfillSource,
   EventTopicTriggerCreationError,
 } from '../../definitions/index.js';
@@ -30,7 +32,18 @@ describe('EventTopicBackfillForAll', () => {
   let createTriggerMock: WorkspaceFunctionCallMock<EventTopicBrokerCreateTrigger>;
   let publishEventsMock: WorkspaceFunctionCallMock<EventTopicBrokerPublishEvents>;
   let createBackfillSourceMock: WorkspaceFunctionCallMock<EventTopicCreateBackfillSource>;
+  let waitForProcessingMock: WorkspaceFunctionCallMock<EventTopicBrokerWaitForProcessing>;
+  let cleanBackfillMock: WorkspaceFunctionCallMock<EventTopicCleanBackfill>;
   let backfillSource: AsyncIterable<BackfillEvent>;
+
+  async function fileExists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   beforeEach(async () => {
     tmpDir = resolve(await mkdtemp('causa-test-'));
@@ -72,6 +85,16 @@ describe('EventTopicBackfillForAll', () => {
       EventTopicCreateBackfillSource,
       async () => backfillSource,
     );
+    waitForProcessingMock = registerMockFunction(
+      functionRegistry,
+      EventTopicBrokerWaitForProcessing,
+      () => Promise.resolve(),
+    );
+    cleanBackfillMock = registerMockFunction(
+      functionRegistry,
+      EventTopicCleanBackfill,
+      () => Promise.resolve(),
+    );
   });
 
   afterEach(async () => {
@@ -89,19 +112,19 @@ describe('EventTopicBackfillForAll', () => {
     );
   });
 
-  it('should default the output file to the workspace root', async () => {
+  it('should not write a backfill file when no temporary resources were created', async () => {
     const actualFile = await context.call(EventTopicBackfill, {
       eventTopic: 'test-topic',
     });
 
-    expect(actualFile).toMatch(
-      new RegExp(`^${tmpDir}/backfill-[0-9a-f]+\\.json$`),
-    );
-    const actualFileContent = await readFile(actualFile);
-    expect(JSON.parse(actualFileContent.toString())).toEqual({
-      temporaryTopicId: null,
-      temporaryTriggerResourceIds: [],
+    expect(actualFile).toBe('');
+    expect(publishEventsMock).toHaveBeenCalledExactlyOnceWith(context, {
+      topicId: 'broker/test-topic',
+      eventTopic: 'test-topic',
+      source: expect.any(Function),
     });
+    expect(waitForProcessingMock).not.toHaveBeenCalled();
+    expect(cleanBackfillMock).not.toHaveBeenCalled();
   });
 
   it('should use an existing topic, create triggers, and publish events', async () => {
@@ -250,7 +273,7 @@ describe('EventTopicBackfillForAll', () => {
     });
   });
 
-  it('should still output the backfill file when publishing events fails', async () => {
+  it('should not write a backfill file when publishing fails with no temporary resources', async () => {
     const expectedFile = resolve(tmpDir, 'backfill.json');
     publishEventsMock.mockImplementation(async () => {
       throw new Error('💥');
@@ -272,10 +295,29 @@ describe('EventTopicBackfillForAll', () => {
       eventTopic: 'test-topic',
       source: expect.any(Function),
     });
+    expect(await fileExists(expectedFile)).toBe(false);
+  });
+
+  it('should write the backfill file when publishing fails with temporary resources', async () => {
+    const expectedFile = resolve(tmpDir, 'backfill.json');
+    publishEventsMock.mockImplementation(async () => {
+      throw new Error('💥');
+    });
+
+    const actualPromise = context.call(EventTopicBackfill, {
+      eventTopic: 'test-topic',
+      triggers: ['trigger1'],
+      output: expectedFile,
+    });
+
+    await expect(actualPromise).rejects.toThrow('💥');
+    const actualBackfillId = createTriggerMock.mock.calls[0][1].backfillId;
     const actualFileContent = await readFile(expectedFile);
     expect(JSON.parse(actualFileContent.toString())).toEqual({
       temporaryTopicId: null,
-      temporaryTriggerResourceIds: [],
+      temporaryTriggerResourceIds: [
+        `backfill/${actualBackfillId}/broker/test-topic/trigger/trigger1`,
+      ],
     });
   });
 
@@ -340,11 +382,7 @@ describe('EventTopicBackfillForAll', () => {
     await expect(actualPromise).rejects.toThrow('💥 nope');
     expect(createTriggerMock).not.toHaveBeenCalled();
     expect(publishEventsMock).not.toHaveBeenCalled();
-    const actualFileContent = await readFile(expectedFile);
-    expect(JSON.parse(actualFileContent.toString())).toEqual({
-      temporaryTopicId: null,
-      temporaryTriggerResourceIds: [],
-    });
+    expect(await fileExists(expectedFile)).toBe(false);
   });
 
   it('should fail when the cloned context has no project path', async () => {
@@ -371,10 +409,151 @@ describe('EventTopicBackfillForAll', () => {
     );
     expect(createTriggerMock).not.toHaveBeenCalled();
     expect(publishEventsMock).not.toHaveBeenCalled();
-    const actualFileContent = await readFile(expectedFile);
-    expect(JSON.parse(actualFileContent.toString())).toEqual({
-      temporaryTopicId: null,
-      temporaryTriggerResourceIds: [],
+    expect(await fileExists(expectedFile)).toBe(false);
+  });
+
+  describe('autoClean', () => {
+    it('should publish without waiting or cleaning when no temporary resources are created', async () => {
+      const expectedFile = resolve(tmpDir, 'backfill.json');
+
+      const actualFile = await context.call(EventTopicBackfill, {
+        eventTopic: 'test-topic',
+        autoClean: true,
+        output: expectedFile,
+      });
+
+      expect(actualFile).toBe('');
+      expect(publishEventsMock).toHaveBeenCalledExactlyOnceWith(context, {
+        topicId: 'broker/test-topic',
+        eventTopic: 'test-topic',
+        source: expect.any(Function),
+      });
+      expect(waitForProcessingMock).not.toHaveBeenCalled();
+      expect(cleanBackfillMock).not.toHaveBeenCalled();
+      expect(await fileExists(expectedFile)).toBe(false);
+    });
+
+    it('should wait then clean and not persist the backfill file on success', async () => {
+      const expectedFile = resolve(tmpDir, 'backfill.json');
+      let fileContentAtCleanCall: string | null = null;
+      cleanBackfillMock.mockImplementation(async (_, { file }) => {
+        fileContentAtCleanCall = (await readFile(file)).toString();
+      });
+
+      const actualFile = await context.call(EventTopicBackfill, {
+        eventTopic: 'test-topic',
+        triggers: ['trigger1'],
+        createTemporaryTopic: true,
+        autoClean: true,
+        output: expectedFile,
+      });
+
+      expect(actualFile).toBe('');
+      const actualTopicName = createTopicMock.mock.calls[0][1].name;
+      const expectedTopicId = `created/${actualTopicName}`;
+      const actualBackfillId = createTriggerMock.mock.calls[0][1].backfillId;
+      const expectedTemporaryData = {
+        temporaryTopicId: expectedTopicId,
+        temporaryTriggerResourceIds: [
+          `backfill/${actualBackfillId}/${expectedTopicId}/trigger/trigger1`,
+        ],
+      };
+      expect(waitForProcessingMock).toHaveBeenCalledExactlyOnceWith(context, {
+        eventTopic: 'test-topic',
+        temporaryData: expectedTemporaryData,
+      });
+      expect(cleanBackfillMock).toHaveBeenCalledExactlyOnceWith(context, {
+        file: expectedFile,
+      });
+      expect(JSON.parse(fileContentAtCleanCall!)).toEqual(
+        expectedTemporaryData,
+      );
+      expect(await fileExists(expectedFile)).toBe(false);
+    });
+
+    it('should persist the backfill file when waiting for processing fails', async () => {
+      const expectedFile = resolve(tmpDir, 'backfill.json');
+      waitForProcessingMock.mockImplementation(async () => {
+        throw new Error('💥 timeout');
+      });
+
+      const actualPromise = context.call(EventTopicBackfill, {
+        eventTopic: 'test-topic',
+        triggers: ['trigger1'],
+        createTemporaryTopic: true,
+        autoClean: true,
+        output: expectedFile,
+      });
+
+      await expect(actualPromise).rejects.toThrow('💥 timeout');
+      expect(cleanBackfillMock).not.toHaveBeenCalled();
+      const actualTopicName = createTopicMock.mock.calls[0][1].name;
+      const expectedTopicId = `created/${actualTopicName}`;
+      const actualBackfillId = createTriggerMock.mock.calls[0][1].backfillId;
+      const actualFileContent = await readFile(expectedFile);
+      expect(JSON.parse(actualFileContent.toString())).toEqual({
+        temporaryTopicId: expectedTopicId,
+        temporaryTriggerResourceIds: [
+          `backfill/${actualBackfillId}/${expectedTopicId}/trigger/trigger1`,
+        ],
+      });
+    });
+
+    it('should persist the backfill file when cleaning fails', async () => {
+      const expectedFile = resolve(tmpDir, 'backfill.json');
+      cleanBackfillMock.mockImplementation(async () => {
+        throw new Error('💥 clean');
+      });
+
+      const actualPromise = context.call(EventTopicBackfill, {
+        eventTopic: 'test-topic',
+        triggers: ['trigger1'],
+        createTemporaryTopic: true,
+        autoClean: true,
+        output: expectedFile,
+      });
+
+      await expect(actualPromise).rejects.toThrow('💥 clean');
+      expect(waitForProcessingMock).toHaveBeenCalledOnce();
+      const actualTopicName = createTopicMock.mock.calls[0][1].name;
+      const expectedTopicId = `created/${actualTopicName}`;
+      const actualBackfillId = createTriggerMock.mock.calls[0][1].backfillId;
+      const actualFileContent = await readFile(expectedFile);
+      expect(JSON.parse(actualFileContent.toString())).toEqual({
+        temporaryTopicId: expectedTopicId,
+        temporaryTriggerResourceIds: [
+          `backfill/${actualBackfillId}/${expectedTopicId}/trigger/trigger1`,
+        ],
+      });
+    });
+
+    it('should not wait or clean when publishing fails', async () => {
+      const expectedFile = resolve(tmpDir, 'backfill.json');
+      publishEventsMock.mockImplementation(async () => {
+        throw new Error('💥 publish');
+      });
+
+      const actualPromise = context.call(EventTopicBackfill, {
+        eventTopic: 'test-topic',
+        triggers: ['trigger1'],
+        createTemporaryTopic: true,
+        autoClean: true,
+        output: expectedFile,
+      });
+
+      await expect(actualPromise).rejects.toThrow('💥 publish');
+      expect(waitForProcessingMock).not.toHaveBeenCalled();
+      expect(cleanBackfillMock).not.toHaveBeenCalled();
+      const actualTopicName = createTopicMock.mock.calls[0][1].name;
+      const expectedTopicId = `created/${actualTopicName}`;
+      const actualBackfillId = createTriggerMock.mock.calls[0][1].backfillId;
+      const actualFileContent = await readFile(expectedFile);
+      expect(JSON.parse(actualFileContent.toString())).toEqual({
+        temporaryTopicId: expectedTopicId,
+        temporaryTriggerResourceIds: [
+          `backfill/${actualBackfillId}/${expectedTopicId}/trigger/trigger1`,
+        ],
+      });
     });
   });
 });

--- a/src/functions/event-topic/backfill.ts
+++ b/src/functions/event-topic/backfill.ts
@@ -1,6 +1,6 @@
 import { WorkspaceContext } from '@causa/workspace';
 import { randomBytes } from 'crypto';
-import { writeFile } from 'fs/promises';
+import { unlink, writeFile } from 'fs/promises';
 import { join, resolve } from 'path';
 import {
   type BackfillTemporaryData,
@@ -9,6 +9,8 @@ import {
   EventTopicBrokerCreateTrigger,
   EventTopicBrokerGetTopicId,
   EventTopicBrokerPublishEvents,
+  EventTopicBrokerWaitForProcessing,
+  EventTopicCleanBackfill,
   EventTopicCreateBackfillSource,
   EventTopicTriggerCreationError,
 } from '../../definitions/index.js';
@@ -191,6 +193,8 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
       `"${backfillFile}"`,
     ].join(' ');
 
+    let hasTempResources = false;
+    let publishFailed = false;
     try {
       await this.createTriggers(backfillId, topicId, temporaryData);
 
@@ -210,19 +214,60 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
       });
 
       this._context.logger.info('✅ Successfully published all events.');
-      this._context.logger.info(
-        `💡 Once backfilling is complete, temporary resources can be cleaned using '${cleanBackfillCommand}'.`,
-      );
     } catch (error) {
-      this._context.logger.warn(
-        `⚠️ Backfilling failed but there might be temporary resources to clean up using '${cleanBackfillCommand}'.`,
-      );
+      publishFailed = true;
       throw error;
     } finally {
-      await writeFile(backfillFile, JSON.stringify(temporaryData));
+      hasTempResources =
+        !!temporaryData.temporaryTopicId ||
+        temporaryData.temporaryTriggerResourceIds.length > 0;
+      if (hasTempResources) {
+        if (publishFailed) {
+          this._context.logger.warn(
+            `⚠️ Backfilling failed but there might be temporary resources to clean up using '${cleanBackfillCommand}'.`,
+          );
+        }
+
+        await writeFile(backfillFile, JSON.stringify(temporaryData));
+      }
     }
 
-    return backfillFile;
+    if (!this.autoClean) {
+      if (hasTempResources) {
+        this._context.logger.info(
+          `💡 Once backfilling is complete, temporary resources can be cleaned using '${cleanBackfillCommand}'.`,
+        );
+      }
+      return hasTempResources ? backfillFile : '';
+    }
+
+    if (!hasTempResources) {
+      this._context.logger.info(
+        'ℹ️ No temporary resources were created, skipping wait and clean.',
+      );
+      return '';
+    }
+
+    try {
+      this._context.logger.info(
+        '⏳ Waiting for events to be processed before cleaning up.',
+      );
+      await this._context.call(EventTopicBrokerWaitForProcessing, {
+        eventTopic: this.eventTopic,
+        temporaryData,
+      });
+
+      await this._context.call(EventTopicCleanBackfill, { file: backfillFile });
+    } catch (error) {
+      this._context.logger.warn(
+        `⚠️ Auto-clean failed, temporary resources can be cleaned using '${cleanBackfillCommand}'.`,
+      );
+      throw error;
+    }
+
+    await unlink(backfillFile);
+
+    return '';
   }
 
   _supports(): boolean {


### PR DESCRIPTION
### 📝 Description of the PR

Adds a `--autoClean` option to `cs events backfill` so the command can publish events, wait for them to be processed, and run the equivalent of `cleanBackfill` inline — turning the whole backfilling flow into a single CLI call instead of two manual steps separated by a wait.

The wait stage is delegated to a new broker-specific workspace function, `EventTopicBrokerWaitForProcessing`, that other modules need to implement to support `--autoClean` (timeout and "processed" semantics are decided by the implementation). On success, no backfill file is persisted and the command outputs nothing. If publishing, waiting, or cleaning fails, the backfill file is left on disk and the usual hint for running `cleanBackfill` manually is printed.

While reworking the flow, the backfill file is also no longer written when no temporary resources were created at all (no temporary topic and no triggers, or a failure before any temporary resource exists). In that case the command returns an empty string and produces no output, which is a breaking change for callers that relied on a backfill file always being written.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.