### PR TITLE
🔖 Prepare v0.35.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Support JSONSchema `anyOf` unions during parsing and writing.
+- Support inline object, enum, and union schemas declared as variants of a `oneOf` or `anyOf`.
+
 ## v0.35.0-beta.5 (2026-05-26)
 
 Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.0-beta.5 (2026-05-26)
+
 Breaking changes:
 
 - `cs events backfill` no longer writes a backfill file when no temporary resources were created (e.g. no temporary topic and no triggers, or when the command fails before any temporary resource exists). In that case, the command returns an empty string instead of a path, and its output is suppressed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.4",
+  "version": "0.35.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.35.0-beta.4",
+      "version": "0.35.0-beta.5",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.4",
+  "version": "0.35.0-beta.5",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",

--- a/src/definitions/model.types.ts
+++ b/src/definitions/model.types.ts
@@ -184,6 +184,14 @@ export type UnionSchema = BaseSchema & {
   kind: 'union';
 
   /**
+   * The way types are combined in this union.
+   *
+   * - `oneOf` requires exactly one variant to match (exclusive).
+   * - `anyOf` requires at least one variant to match (inclusive).
+   */
+  combiner: 'oneOf' | 'anyOf';
+
+  /**
    * The non-null member types of the union, in source order.
    */
   types: PropertyType[];

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -837,6 +837,188 @@ properties:
       expect(inline).toMatchObject({ kind: 'object', name: 'byIdValue' });
     });
 
+    it('should extract an inline object variant inside a top-level union', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Either
+oneOf:
+  - title: Address
+    type: object
+    properties:
+      street:
+        type: string
+  - type: string`,
+        path,
+      );
+
+      const variantPointer = `${path}#/oneOf/0`;
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ kind: 'object', path: variantPointer });
+      expect(schemas[0]).toMatchObject({
+        kind: 'union',
+        name: 'Either',
+        types: [
+          { kind: 'ref', ref: variantPointer },
+          { kind: 'primitive', type: 'string' },
+        ],
+      });
+    });
+
+    it('should extract an inline enum variant inside a top-level union', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Either
+oneOf:
+  - type: integer
+  - title: Status
+    type: string
+    enum: [active, archived]`,
+        path,
+      );
+
+      const variantPointer = `${path}#/oneOf/1`;
+      const inline = schemas.find((s) => s.name === 'Status');
+      expect(inline).toMatchObject({
+        kind: 'enum',
+        type: 'string',
+        values: ['active', 'archived'],
+        path: variantPointer,
+      });
+      expect((schemas[0] as any).types).toEqual([
+        { kind: 'primitive', type: 'integer' },
+        { kind: 'ref', ref: variantPointer },
+      ]);
+    });
+
+    it('should extract an inline object variant inside a property union', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  value:
+    title: Value
+    oneOf:
+      - title: Address
+        type: object
+        properties:
+          street:
+            type: string
+      - type: string`,
+        path,
+      );
+
+      const unionPointer = `${path}#/properties/value`;
+      const variantPointer = `${unionPointer}/oneOf/0`;
+      const union = schemas.find((s) => s.name === 'Value');
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(union).toMatchObject({
+        kind: 'union',
+        path: unionPointer,
+        types: [
+          { kind: 'ref', ref: variantPointer },
+          { kind: 'primitive', type: 'string' },
+        ],
+      });
+      expect(inline).toMatchObject({ kind: 'object', path: variantPointer });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: unionPointer },
+      });
+    });
+
+    it('should recursively extract inline schemas nested inside union variants', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  value:
+    title: Value
+    oneOf:
+      - title: Wrapper
+        type: object
+        properties:
+          inner:
+            title: Inner
+            oneOf:
+              - title: Detail
+                type: object
+                properties:
+                  label:
+                    type: string
+              - type: integer
+      - type: string`,
+        path,
+      );
+
+      const valuePointer = `${path}#/properties/value`;
+      const wrapperPointer = `${valuePointer}/oneOf/0`;
+      const innerPointer = `${wrapperPointer}/properties/inner`;
+      const detailPointer = `${innerPointer}/oneOf/0`;
+
+      const value = schemas.find((s) => s.name === 'Value');
+      const wrapper = schemas.find((s) => s.name === 'Wrapper');
+      const inner = schemas.find((s) => s.name === 'Inner');
+      const detail = schemas.find((s) => s.name === 'Detail');
+
+      expect(value).toMatchObject({
+        kind: 'union',
+        path: valuePointer,
+        types: [
+          { kind: 'ref', ref: wrapperPointer },
+          { kind: 'primitive', type: 'string' },
+        ],
+      });
+      expect(wrapper).toMatchObject({
+        kind: 'object',
+        path: wrapperPointer,
+        properties: [
+          {
+            name: 'inner',
+            type: { kind: 'ref', ref: innerPointer },
+          },
+        ],
+      });
+      expect(inner).toMatchObject({
+        kind: 'union',
+        path: innerPointer,
+        types: [
+          { kind: 'ref', ref: detailPointer },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      });
+      expect(detail).toMatchObject({
+        kind: 'object',
+        path: detailPointer,
+        properties: [
+          {
+            name: 'label',
+            type: { kind: 'primitive', type: 'string' },
+          },
+        ],
+      });
+    });
+
+    it('should fall back to `${unionName}Variant${i}` for an untitled inline variant', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Either
+oneOf:
+  - type: object
+    properties:
+      street:
+        type: string
+  - type: string`,
+        path,
+      );
+
+      const inline = schemas.find((s) => s.path === `${path}#/oneOf/0`);
+      expect(inline).toMatchObject({
+        kind: 'object',
+        name: 'EitherVariant0',
+      });
+    });
+
     it('should extract inline object schemas with their own path', () => {
       const schemas = parseJsonSchema(
         `

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -58,10 +58,50 @@ oneOf:
       expect(schema).toMatchObject({
         kind: 'union',
         name: 'Either',
+        combiner: 'oneOf',
         types: [
           { kind: 'primitive', type: 'string' },
           { kind: 'primitive', type: 'integer' },
         ],
+      });
+    });
+
+    it('should parse a top-level anyOf union', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: Either
+anyOf:
+  - type: string
+  - type: integer`,
+        path,
+      );
+
+      expect(schema).toMatchObject({
+        kind: 'union',
+        name: 'Either',
+        combiner: 'anyOf',
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      });
+    });
+
+    it('should parse a top-level nullable anyOf union with a single non-null variant', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: Maybe
+anyOf:
+  - type: string
+  - type: "null"`,
+        path,
+      );
+
+      expect(schema).toMatchObject({
+        kind: 'union',
+        name: 'Maybe',
+        combiner: 'anyOf',
+        types: [{ kind: 'primitive', type: 'string' }, { kind: 'null' }],
       });
     });
 
@@ -334,7 +374,7 @@ properties:
       - type: "null"`,
           path,
         ),
-      ).toThrow(/cannot combine an array .type. with .oneOf./);
+      ).toThrow(/cannot combine an array .type. with .oneOf. or .anyOf./);
     });
 
     it('should parse array with nullable items', () => {
@@ -835,6 +875,141 @@ properties:
         (s) => s.path === `${path}#/properties/byId/additionalProperties`,
       );
       expect(inline).toMatchObject({ kind: 'object', name: 'byIdValue' });
+    });
+
+    it('should extract an inline anyOf union declared on a property with the anyOf-suffixed pointer', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  value:
+    title: Value
+    anyOf:
+      - type: string
+      - type: integer`,
+        path,
+      );
+
+      const unionPointer = `${path}#/properties/value`;
+      const union = schemas.find((s) => s.name === 'Value');
+      expect(union).toMatchObject({
+        kind: 'union',
+        combiner: 'anyOf',
+        path: unionPointer,
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: unionPointer },
+        nullable: false,
+      });
+    });
+
+    it('should unwrap a property anyOf with a single non-null variant as nullable', () => {
+      const [schema] = parseJsonSchema(
+        `
+title: U
+type: object
+properties:
+  name:
+    anyOf:
+      - type: string
+      - type: "null"`,
+        path,
+      );
+
+      expect((schema as any).properties[0]).toMatchObject({
+        type: { kind: 'primitive', type: 'string' },
+        nullable: true,
+      });
+    });
+
+    it('should extract a nullable inline object schema with the anyOf-suffixed pointer', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Root
+type: object
+properties:
+  address:
+    anyOf:
+      - title: Address
+        type: object
+        properties:
+          street:
+            type: string
+      - type: "null"`,
+        path,
+      );
+
+      const inlinePointer = `${path}#/properties/address/anyOf/0`;
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ kind: 'object', path: inlinePointer });
+      expect((schemas[0] as any).properties[0]).toMatchObject({
+        type: { kind: 'ref', ref: inlinePointer },
+        nullable: true,
+      });
+    });
+
+    it('should extract an inline object variant inside a top-level anyOf union', () => {
+      const schemas = parseJsonSchema(
+        `
+title: Either
+anyOf:
+  - title: Address
+    type: object
+    properties:
+      street:
+        type: string
+  - type: string`,
+        path,
+      );
+
+      const variantPointer = `${path}#/anyOf/0`;
+      const inline = schemas.find((s) => s.name === 'Address');
+      expect(inline).toMatchObject({ kind: 'object', path: variantPointer });
+      expect(schemas[0]).toMatchObject({
+        kind: 'union',
+        combiner: 'anyOf',
+        types: [
+          { kind: 'ref', ref: variantPointer },
+          { kind: 'primitive', type: 'string' },
+        ],
+      });
+    });
+
+    it('should reject combining oneOf and anyOf on the same node', () => {
+      expect(() =>
+        parseJsonSchema(
+          `
+title: Either
+oneOf:
+  - type: string
+  - type: integer
+anyOf:
+  - type: boolean`,
+          path,
+        ),
+      ).toThrow(/cannot combine .oneOf. and .anyOf./);
+    });
+
+    it('should reject combining an array `type` with `anyOf`', () => {
+      expect(() =>
+        parseJsonSchema(
+          `
+title: U
+type: object
+properties:
+  name:
+    type: [string, "null"]
+    anyOf:
+      - type: string
+      - type: "null"`,
+          path,
+        ),
+      ).toThrow(/cannot combine an array .type. with .oneOf. or .anyOf./);
     });
 
     it('should extract an inline object variant inside a top-level union', () => {

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -167,11 +167,25 @@ function parseSchemaBody(
   }
 
   if (schema.oneOf) {
+    const selfPointer = path.includes('#') ? path : `${path}#`;
+    const nested: Schema[] = [];
     const types = schema.oneOf
-      .filter((t): t is JSONSchema7 => typeof t === 'object')
-      .map((t) => resolveInnerType(t, path));
+      .map((t, i) => ({ t, i }))
+      .filter(
+        (e): e is { t: JSONSchema7; i: number } => typeof e.t === 'object',
+      )
+      .map(({ t, i }) =>
+        resolveInnerType(t as CausaSchema, path, {
+          schemas: nested,
+          pointer: `${selfPointer}/oneOf/${i}`,
+          fallbackName: `${name}Variant${i}`,
+        }),
+      );
 
-    return [{ kind: 'union', name, path, description, types, extensions }];
+    return [
+      { kind: 'union', name, path, description, types, extensions },
+      ...nested,
+    ];
   }
 
   if (schema.type !== 'object') {

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -11,6 +11,7 @@ import {
   type Property,
   type PropertyType,
   type Schema,
+  type UnionSchema,
 } from '../definitions/index.js';
 
 /**
@@ -45,6 +46,33 @@ type InlineContext = {
    */
   fallbackName: string;
 };
+
+/**
+ * Identifies the JSON Schema combiner keyword used by a node, if any, returning its key and variants.
+ *
+ * @param schema Raw schema node.
+ * @param path Absolute path of the containing schema, used for error reporting.
+ * @returns The combiner key and its variant list, or `null` when neither keyword is present.
+ * @throws {InvalidSchemaError} When both `oneOf` and `anyOf` are declared on the same node.
+ */
+function readCombiner(
+  schema: CausaSchema,
+  path: string,
+): { key: UnionSchema['combiner']; variants: JSONSchema7[] } | null {
+  if (schema.oneOf && schema.anyOf) {
+    throw new InvalidSchemaError(
+      path,
+      'cannot combine `oneOf` and `anyOf` on the same node',
+    );
+  }
+  if (schema.oneOf) {
+    return { key: 'oneOf', variants: schema.oneOf as JSONSchema7[] };
+  }
+  if (schema.anyOf) {
+    return { key: 'anyOf', variants: schema.anyOf as JSONSchema7[] };
+  }
+  return null;
+}
 
 /**
  * Set of primitive type names recognized by the model.
@@ -166,24 +194,31 @@ function parseSchemaBody(
     ];
   }
 
-  if (schema.oneOf) {
+  const combiner = readCombiner(schema, path);
+  if (combiner) {
+    const { key, variants } = combiner;
     const selfPointer = path.includes('#') ? path : `${path}#`;
     const nested: Schema[] = [];
-    const types = schema.oneOf
-      .map((t, i) => ({ t, i }))
-      .filter(
-        (e): e is { t: JSONSchema7; i: number } => typeof e.t === 'object',
-      )
-      .map(({ t, i }) =>
-        resolveInnerType(t as CausaSchema, path, {
-          schemas: nested,
-          pointer: `${selfPointer}/oneOf/${i}`,
-          fallbackName: `${name}Variant${i}`,
-        }),
-      );
+    const types = variants.flatMap((t, i) =>
+      typeof t === 'object'
+        ? resolveInnerType(t as CausaSchema, path, {
+            schemas: nested,
+            pointer: `${selfPointer}/${key}/${i}`,
+            fallbackName: `${name}Variant${i}`,
+          })
+        : [],
+    );
 
     return [
-      { kind: 'union', name, path, description, types, extensions },
+      {
+        kind: 'union',
+        name,
+        path,
+        description,
+        combiner: key,
+        types,
+        extensions,
+      },
       ...nested,
     ];
   }
@@ -295,12 +330,14 @@ function tryResolveInlineSchema(
   prop: CausaSchema,
   pointer: string,
   fallbackName: string,
+  path: string,
 ): { type: PropertyType; nested: Schema[] } | null {
   const isEnum = Array.isArray(prop.enum);
   const isObject = prop.type === 'object' && prop.properties !== undefined;
+  const combiner = readCombiner(prop, path);
   const isUnion =
-    Array.isArray(prop.oneOf) &&
-    prop.oneOf.filter((v) => typeof v === 'object' && v.type !== 'null')
+    combiner !== null &&
+    combiner.variants.filter((v) => typeof v === 'object' && v.type !== 'null')
       .length >= 2;
   if (!isEnum && !isObject && !isUnion) {
     return null;
@@ -337,13 +374,13 @@ function unwrapNullableOneOf(
   path: string,
 ): { inner: CausaSchema; nullable: boolean; pointer: string } {
   const normalized = expandTypeArray(prop, path);
-  const oneOf = normalized.oneOf as CausaSchema[] | undefined;
-  if (!oneOf) {
+  const combiner = readCombiner(normalized, path);
+  if (!combiner) {
     return { inner: normalized, nullable: false, pointer };
   }
 
-  const nullable = oneOf.some((v) => v.type === 'null');
-  const nonNullIndices = oneOf.flatMap((v, i) =>
+  const nullable = combiner.variants.some((v) => v.type === 'null');
+  const nonNullIndices = combiner.variants.flatMap((v, i) =>
     v.type === 'null' ? [] : [i],
   );
 
@@ -353,7 +390,11 @@ function unwrapNullableOneOf(
 
   if (nonNullIndices.length === 1) {
     const idx = nonNullIndices[0];
-    return { inner: oneOf[idx], nullable, pointer: `${pointer}/oneOf/${idx}` };
+    return {
+      inner: combiner.variants[idx],
+      nullable,
+      pointer: `${pointer}/${combiner.key}/${idx}`,
+    };
   }
 
   return { inner: normalized, nullable: false, pointer };
@@ -378,10 +419,10 @@ function expandTypeArray(prop: CausaSchema, path: string): CausaSchema {
   if (!Array.isArray(prop.type)) {
     return prop;
   }
-  if (prop.oneOf !== undefined) {
+  if (prop.oneOf !== undefined || prop.anyOf !== undefined) {
     throw new InvalidSchemaError(
       path,
-      'cannot combine an array `type` with `oneOf`',
+      'cannot combine an array `type` with `oneOf` or `anyOf`',
     );
   }
 
@@ -418,6 +459,7 @@ function resolveInnerType(
       prop,
       inline.pointer,
       inline.fallbackName,
+      path,
     );
     if (matched) {
       inline.schemas.push(...matched.nested);

--- a/src/jsonschema/writer.spec.ts
+++ b/src/jsonschema/writer.spec.ts
@@ -117,11 +117,12 @@ describe('apply', () => {
     });
   });
 
-  it('should write a union schema', () => {
+  it('should write a oneOf union schema', () => {
     const schema: UnionSchema = {
       kind: 'union',
       name: 'Either',
       path: filePath,
+      combiner: 'oneOf',
       types: [
         { kind: 'primitive', type: 'string' },
         { kind: 'primitive', type: 'integer' },
@@ -135,6 +136,52 @@ describe('apply', () => {
     expect(parsed).toEqual({
       title: 'Either',
       oneOf: [{ type: 'string' }, { type: 'integer' }],
+    });
+  });
+
+  it('should write an anyOf union schema', () => {
+    const schema: UnionSchema = {
+      kind: 'union',
+      name: 'Either',
+      path: filePath,
+      combiner: 'anyOf',
+      types: [
+        { kind: 'primitive', type: 'string' },
+        { kind: 'primitive', type: 'integer' },
+      ],
+      extensions: {},
+    };
+
+    const out = apply('', schema);
+
+    const parsed = yaml.parse(out);
+    expect(parsed).toEqual({
+      title: 'Either',
+      anyOf: [{ type: 'string' }, { type: 'integer' }],
+    });
+  });
+
+  it('should rewrite a union when switching combiner', () => {
+    const initial =
+      'title: Either\noneOf:\n  - type: string\n  - type: integer\n';
+    const schema: UnionSchema = {
+      kind: 'union',
+      name: 'Either',
+      path: filePath,
+      combiner: 'anyOf',
+      types: [
+        { kind: 'primitive', type: 'string' },
+        { kind: 'primitive', type: 'integer' },
+      ],
+      extensions: {},
+    };
+
+    const out = apply(initial, schema);
+
+    const parsed = yaml.parse(out);
+    expect(parsed).toEqual({
+      title: 'Either',
+      anyOf: [{ type: 'string' }, { type: 'integer' }],
     });
   });
 

--- a/src/jsonschema/writer.ts
+++ b/src/jsonschema/writer.ts
@@ -22,6 +22,7 @@ const TYPE_KEYWORDS = [
   'type',
   'format',
   'oneOf',
+  'anyOf',
   'items',
   '$ref',
   'enum',
@@ -339,9 +340,9 @@ function applyUnion(
 ): void {
   const target: Record<string, unknown> = {
     title: schema.name,
-    oneOf: schema.types.map((t) => buildTypeNode(t, filePath)),
+    [schema.combiner]: schema.types.map((t) => buildTypeNode(t, filePath)),
   };
-  applyMinimalChange(node, target, excludeTypeKeywordsExcept('oneOf'));
+  applyMinimalChange(node, target, excludeTypeKeywordsExcept(schema.combiner));
   applyDescription(node, schema.description);
   applyExtensions(node, schema.extensions, filePath);
 }


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- `cs events backfill` no longer writes a backfill file when no temporary resources were created (e.g. no temporary topic and no triggers, or when the command fails before any temporary resource exists). In that case, the command returns an empty string instead of a path, and its output is suppressed.

Features:

- Add the `--autoClean` option to `cs events backfill`, which waits for events to be processed after publishing and runs `cleanBackfill` inline. Introduces the broker-side `EventTopicBrokerWaitForProcessing` workspace function, which implementations should provide to support `--autoClean`.
- Parse the `additionalProperties` declaration on object schemas during JSONSchema parsing, exposing it on `ObjectSchema.additionalProperties` as a boolean or a resolved `PropertyType` (with inline object, enum, and union shapes extracted as nested schemas, like map values).

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~