### PR TITLE
🔖 Prepare v0.35.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.0-beta.6 (2026-05-27)
+
 Features:
 
 - Support JSONSchema `anyOf` unions during parsing and writing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.5",
+  "version": "0.35.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.35.0-beta.5",
+      "version": "0.35.0-beta.6",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.5",
+  "version": "0.35.0-beta.6",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Support JSONSchema `anyOf` unions during parsing and writing.
- Support inline object, enum, and union schemas declared as variants of a `oneOf` or `anyOf`.

Chores:

- Update configuration schemas for compatibility with new code generation.