### PR TITLE
✨ Improve scenario templating and HTTP request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+Features:
+
+- Add the `rand` function to scenario templates, generating a random UUID (`rand('uuid')`), integer (`rand('int', min, max)`), or floating-point number (`rand('float', min, max)`).
+- Support `multipart/form-data` bodies in `HttpMakeRequest`: when the `Content-Type` header is `multipart/form-data`, the `body` object is sent as a form.
+- JSON-serialize the `HttpMakeRequest` body (even when it is a string) when the `Content-Type` header is set to `application/json`.
+
+Fixes:
+
+- Detect scenario step dependencies across all `json-e` expression forms, including member access, indexing, builtins, both branches of `$if`/`$switch`, and multiple interpolations in a single string.
+- Allow any JSON value (string, number, boolean, object, array, or null) as a scenario step expectation `value`.
+
 ## v0.35.0-beta.6 (2026-05-27)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ Step `args` and `expectations` are rendered with [json-e](https://json-e.js.org/
 - `${ output('<stepId>') }` — resolves another step's output (and is also used to detect cross-step dependencies).
 - `${ configuration('<path>') }` — resolves a value from the workspace configuration.
 - `${ str(<value>) }` — overrides the json-e builtin to also format `Date` values as ISO strings.
+- `${ rand('uuid') }`, `${ rand('int', <min>, <max>) }`, `${ rand('float', <min>, <max>) }` — generates a random UUID, integer, or floating-point number (the bounded variants in `[min, max)`).

--- a/causa.yaml
+++ b/causa.yaml
@@ -11,8 +11,8 @@ project:
 
 causa:
   modules:
-    '@causa/workspace-core': '>= 0.29.0'
-    '@causa/workspace-typescript': '>= 0.19.2'
+    '@causa/workspace-core': '>= 0.35.0-beta.6'
+    '@causa/workspace-typescript': '>= 0.23.0-beta.4'
 
 javascript:
   dependencies:

--- a/src/definitions/http.ts
+++ b/src/definitions/http.ts
@@ -3,6 +3,38 @@ import { AllowMissing } from '@causa/workspace/validation';
 import { IsObject, IsString } from 'class-validator';
 
 /**
+ * A single field of a `multipart/form-data` request body. Such a body is sent by setting {@link HttpMakeRequest.body}
+ * to an object keyed by field name and the `Content-Type` header to `multipart/form-data`.
+ */
+export type HttpFormField =
+  | string
+  | ({
+      /**
+       * The filename to advertise for the part, which sends the field as a file rather than a text field. For a `path`
+       * part, defaults to the basename of the path.
+       */
+      readonly filename?: string;
+
+      /**
+       * The content type of the part.
+       */
+      readonly contentType?: string;
+    } & (
+      | {
+          /**
+           * The inline content of the part.
+           */
+          readonly value: string;
+        }
+      | {
+          /**
+           * The path to a local file, resolved from the workspace root, whose content is sent as the part.
+           */
+          readonly path: string;
+        }
+    ));
+
+/**
  * The result of a {@link HttpMakeRequest} call.
  */
 export type HttpResponse = {
@@ -64,7 +96,11 @@ export abstract class HttpMakeRequest extends WorkspaceFunction<
   readonly headers?: Record<string, string>;
 
   /**
-   * The request body. Objects and arrays are JSON-serialized, strings are sent as-is.
+   * The request body.
+   * - When the `Content-Type` header is `multipart/form-data`, an object is sent as a form (keyed by field name, with
+   *   {@link HttpFormField} values) and the header's boundary is set automatically.
+   * - When the `Content-Type` header is `application/json`, the body is JSON-serialized.
+   * - Otherwise, strings are sent as-is, and objects and arrays are JSON-serialized.
    */
   @AllowMissing()
   readonly body?: any;

--- a/src/functions/http/make-request.spec.ts
+++ b/src/functions/http/make-request.spec.ts
@@ -1,18 +1,27 @@
 import { WorkspaceContext } from '@causa/workspace';
 import { createContext } from '@causa/workspace/testing';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
 import 'jest-extended';
 import nock from 'nock';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { HttpMakeRequest } from '../../definitions/index.js';
 import { HttpMakeRequestForAll } from './make-request.js';
 
 describe('HttpMakeRequestForAll', () => {
+  let tmpDir: string;
   let context: WorkspaceContext;
 
-  beforeEach(() => {
-    ({ context } = createContext({ functions: [HttpMakeRequestForAll] }));
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'causa-http-'));
+    ({ context } = createContext({
+      rootPath: tmpDir,
+      functions: [HttpMakeRequestForAll],
+    }));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
     nock.cleanAll();
   });
 
@@ -55,6 +64,29 @@ describe('HttpMakeRequestForAll', () => {
       statusCode: 201,
       headers: { 'content-type': 'application/json' },
       body: { id: '🆔' },
+    });
+    scope.done();
+  });
+
+  it('should JSON-serialize a string body when the content type is application/json', async () => {
+    const scope = nock('https://api.example.com', {
+      reqheaders: { 'content-type': 'application/json' },
+    })
+      .post('/items', '"already-a-string"')
+      .reply(201, { ok: true }, { 'content-type': 'application/json' });
+
+    const actual = await context.call(HttpMakeRequest, {
+      baseUrl: 'https://api.example.com',
+      method: 'POST',
+      path: '/items',
+      headers: { 'content-type': 'application/json' },
+      body: 'already-a-string',
+    });
+
+    expect(actual).toEqual({
+      statusCode: 201,
+      headers: { 'content-type': 'application/json' },
+      body: { ok: true },
     });
     scope.done();
   });
@@ -119,6 +151,90 @@ describe('HttpMakeRequestForAll', () => {
       body: { ok: true },
     });
     scope.done();
+  });
+
+  it('should send the body as multipart/form-data when the content type requests it', async () => {
+    const scope = nock('https://api.example.com')
+      .matchHeader('content-type', (value) =>
+        value.startsWith('multipart/form-data; boundary='),
+      )
+      .post(
+        '/upload',
+        (body) =>
+          body.includes('name="field"') &&
+          body.includes('hello') &&
+          body.includes('name="file"') &&
+          body.includes('filename="data.txt"') &&
+          body.includes('file-content'),
+      )
+      .reply(200, { ok: true }, { 'content-type': 'application/json' });
+
+    const actual = await context.call(HttpMakeRequest, {
+      baseUrl: 'https://api.example.com',
+      method: 'POST',
+      path: '/upload',
+      headers: { 'content-type': 'multipart/form-data' },
+      body: {
+        field: 'hello',
+        file: {
+          value: 'file-content',
+          filename: 'data.txt',
+          contentType: 'text/plain',
+        },
+      },
+    });
+
+    expect(actual).toEqual({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: { ok: true },
+    });
+    scope.done();
+  });
+
+  it('should send a multipart/form-data file part sourced from a local file path', async () => {
+    await writeFile(join(tmpDir, 'upload.txt'), 'file-from-disk');
+    const scope = nock('https://api.example.com')
+      .matchHeader('content-type', (value) =>
+        value.startsWith('multipart/form-data; boundary='),
+      )
+      .post(
+        '/upload',
+        (body) =>
+          typeof body === 'string' &&
+          body.includes('name="file"') &&
+          body.includes('filename="upload.txt"') &&
+          body.includes('file-from-disk'),
+      )
+      .reply(200, { ok: true }, { 'content-type': 'application/json' });
+
+    const actual = await context.call(HttpMakeRequest, {
+      baseUrl: 'https://api.example.com',
+      method: 'POST',
+      path: '/upload',
+      headers: { 'content-type': 'multipart/form-data' },
+      body: { file: { path: 'upload.txt' } },
+    });
+
+    expect(actual).toEqual({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: { ok: true },
+    });
+    scope.done();
+  });
+
+  it('should throw when a multipart/form-data body is not an object', async () => {
+    const actualPromise = context.call(HttpMakeRequest, {
+      baseUrl: 'https://api.example.com',
+      method: 'POST',
+      headers: { 'content-type': 'multipart/form-data' },
+      body: 'not-an-object',
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "A 'multipart/form-data' request body must be an object",
+    );
   });
 
   it('should expose error responses without throwing', async () => {

--- a/src/functions/http/make-request.ts
+++ b/src/functions/http/make-request.ts
@@ -1,4 +1,10 @@
-import { type HttpResponse, HttpMakeRequest } from '../../definitions/index.js';
+import { readFile } from 'fs/promises';
+import { basename, resolve } from 'path';
+import {
+  type HttpFormField,
+  type HttpResponse,
+  HttpMakeRequest,
+} from '../../definitions/index.js';
 
 /**
  * Implements {@link HttpMakeRequest} using the native `fetch` API.
@@ -18,15 +24,25 @@ export class HttpMakeRequestForAll extends HttpMakeRequest {
     }
 
     const headers = { ...this.headers };
-    let body: string | undefined;
+    const contentTypeHeader = Object.keys(headers).find(
+      (h) => h.toLowerCase() === 'content-type',
+    );
+    const contentType = headers[contentTypeHeader ?? '']?.toLowerCase();
+    const isFormData = contentType?.includes('multipart/form-data');
+    const isJsonRequest = contentType?.includes('application/json');
+
+    let body: string | FormData | undefined;
     if (this.body !== undefined && method !== 'GET' && method !== 'HEAD') {
-      if (typeof this.body === 'string') {
+      if (isFormData) {
+        // `fetch` sets the `multipart/form-data` content type, including the boundary, from the `FormData` body, so the
+        // header is removed to let it do so.
+        delete headers[contentTypeHeader!];
+        body = await this.buildFormData(this.body);
+      } else if (!isJsonRequest && typeof this.body === 'string') {
         body = this.body;
       } else {
         body = JSON.stringify(this.body);
-        if (
-          !Object.keys(headers).some((h) => h.toLowerCase() === 'content-type')
-        ) {
+        if (contentTypeHeader === undefined) {
           headers['content-type'] = 'application/json';
         }
       }
@@ -49,6 +65,44 @@ export class HttpMakeRequestForAll extends HttpMakeRequest {
       headers: responseHeaders,
       body: responseBody,
     };
+  }
+
+  /**
+   * Builds a {@link FormData} body from a `multipart/form-data` request body. String fields are appended as text;
+   * object fields are appended as file parts, with content sourced from an inline `value` or a local file `path`
+   * (resolved from the workspace root).
+   *
+   * @param body The request body, expected to be an object keyed by field name with {@link HttpFormField} values.
+   * @returns The populated {@link FormData}.
+   */
+  private async buildFormData(body: unknown): Promise<FormData> {
+    if (typeof body !== 'object' || body === null) {
+      throw new Error(
+        "A 'multipart/form-data' request body must be an object keyed by field name.",
+      );
+    }
+
+    const formData = new FormData();
+
+    for (const [name, field] of Object.entries(
+      body as Record<string, HttpFormField>,
+    )) {
+      if (typeof field === 'string') {
+        formData.append(name, field);
+        continue;
+      }
+
+      const hasPath = 'path' in field;
+      const content = hasPath
+        ? await readFile(resolve(this._context.rootPath, field.path))
+        : field.value;
+      const defaultFilename = hasPath ? basename(field.path) : undefined;
+      const blob = new Blob([content], { type: field.contentType ?? '' });
+
+      formData.append(name, blob, field.filename ?? defaultFilename);
+    }
+
+    return formData;
   }
 
   _supports(): boolean {

--- a/src/functions/scenario/run.spec.ts
+++ b/src/functions/scenario/run.spec.ts
@@ -9,8 +9,8 @@ import { AllowMissing } from '@causa/workspace/validation';
 import { IsString } from 'class-validator';
 import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import 'jest-extended';
-import { stringify } from 'yaml';
 import { join, resolve } from 'path';
+import { stringify } from 'yaml';
 import {
   Scenario,
   ScenarioFailedError,
@@ -293,6 +293,44 @@ describe('ScenarioRunForAll', () => {
               value: date.toISOString(),
             },
           ],
+        },
+      },
+    });
+
+    await context.call(ScenarioRun, { path: 'scenario.yaml' });
+  });
+
+  it('should support expectation values that are not strings or objects', async () => {
+    stepMock.mockImplementation(async (_, { value }) => {
+      switch (value) {
+        case 'number':
+          return 42;
+        case 'boolean':
+          return true;
+        case 'array':
+          return [1, 'a'];
+        default:
+          return null;
+      }
+    });
+    await writeScenario({
+      id: 'value-types',
+      steps: {
+        number: {
+          call: { name: 'TestStep', args: { value: 'number' } },
+          expectations: [{ value: 42 }],
+        },
+        boolean: {
+          call: { name: 'TestStep', args: { value: 'boolean' } },
+          expectations: [{ value: true }],
+        },
+        array: {
+          call: { name: 'TestStep', args: { value: 'array' } },
+          expectations: [{ value: [1, 'a'] }],
+        },
+        null: {
+          call: { name: 'TestStep', args: { value: 'null' } },
+          expectations: [{ value: null }],
         },
       },
     });

--- a/src/functions/scenario/run.spec.ts
+++ b/src/functions/scenario/run.spec.ts
@@ -300,6 +300,56 @@ describe('ScenarioRunForAll', () => {
     await context.call(ScenarioRun, { path: 'scenario.yaml' });
   });
 
+  it('should support the rand function for uuids, integers, and floats', async () => {
+    stepMock.mockImplementation(async (_, { value }) => ({ value }));
+    await writeScenario({
+      id: 'rand-builtin',
+      steps: {
+        uuid: {
+          call: { name: 'TestStep', args: { value: "${ rand('uuid') }" } },
+        },
+        int: {
+          call: { name: 'TestStep', args: { value: "${ rand('int', 5, 5) }" } },
+        },
+        float: {
+          call: {
+            name: 'TestStep',
+            args: { value: "${ rand('float', 5.2, 5.2) }" },
+          },
+        },
+      },
+    });
+
+    await context.call(ScenarioRun, { path: 'scenario.yaml' });
+
+    expect(stepMock.mock.calls.map((c) => c[1].value)).toEqual([
+      expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      ),
+      '5',
+      '5.2',
+    ]);
+  });
+
+  it('should fail the step when the rand function is misused', async () => {
+    await writeScenario({
+      id: 'rand-invalid',
+      steps: {
+        only: {
+          call: { name: 'TestStep', args: { value: "${ rand('nope') }" } },
+        },
+      },
+    });
+
+    const actualPromise = context.call(ScenarioRun, { path: 'scenario.yaml' });
+
+    await expect(actualPromise).rejects.toBeInstanceOf(ScenarioFailedError);
+    await expect(actualPromise).rejects.toHaveProperty(
+      'result.steps.only.error',
+      expect.stringContaining("Unsupported 'rand' kind 'nope'"),
+    );
+  });
+
   it('should support expectation values that are not strings or objects', async () => {
     stepMock.mockImplementation(async (_, { value }) => {
       switch (value) {

--- a/src/functions/scenario/run.ts
+++ b/src/functions/scenario/run.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { expect } from 'expect';
 import { readFile, writeFile } from 'fs/promises';
 import jsone from 'json-e';
@@ -25,6 +26,38 @@ class RetryAttemptsExhaustedError extends Error {
   ) {
     super(cause instanceof Error ? cause.message : String(cause), { cause });
   }
+}
+
+/**
+ * Generates a random value, exposed to scenario templates as `rand(...)`:
+ * - `rand('uuid')` returns a random UUID;
+ * - `rand('int', min, max)` returns a random integer in `[min, max)`;
+ * - `rand('float', min, max)` returns a random floating-point number in `[min, max)`.
+ *
+ * @param kind The kind of value to generate (`'uuid'`, `'int'`, or `'float'`).
+ * @param min The lower bound (inclusive), required for `'int'` and `'float'`.
+ * @param max The upper bound (exclusive), required for `'int'` and `'float'`.
+ * @returns The generated value.
+ */
+function rand(kind: unknown, min?: unknown, max?: unknown): string | number {
+  if (kind === 'uuid') {
+    return randomUUID();
+  }
+
+  if (kind !== 'int' && kind !== 'float') {
+    throw new Error(
+      `Unsupported 'rand' kind '${kind}'. Expected 'uuid', 'int' or 'float'.`,
+    );
+  }
+
+  if (typeof min !== 'number' || typeof max !== 'number') {
+    throw new Error(
+      `'rand('${kind}', min, max)' requires numeric 'min' and 'max' bounds.`,
+    );
+  }
+
+  const value = min + Math.random() * (max - min);
+  return kind === 'int' ? Math.floor(value) : value;
 }
 
 /**
@@ -65,6 +98,7 @@ export class ScenarioRunForAll extends ScenarioRun {
       },
       str: (value: any) =>
         value instanceof Date ? value.toISOString() : String(value),
+      rand,
     };
 
     const result = await this.runSteps(

--- a/src/functions/scenario/run.ts
+++ b/src/functions/scenario/run.ts
@@ -1,8 +1,8 @@
 import { expect } from 'expect';
 import { readFile, writeFile } from 'fs/promises';
-import { parse, stringify } from 'yaml';
 import jsone from 'json-e';
 import { resolve } from 'path';
+import { parse, stringify } from 'yaml';
 import {
   type RetryPolicy,
   type Scenario,
@@ -341,7 +341,12 @@ export class ScenarioRunForAll extends ScenarioRun {
         exp.actual !== undefined
           ? jsone(exp.actual, verifyRenderContext)
           : output;
-      const expectedValue = jsone(exp.value, verifyRenderContext);
+      // `value` may be any JSON value. json-e renders all of them, even though its type definition only allows
+      // strings and objects.
+      const expectedValue = jsone(
+        exp.value as Record<string, any> | string,
+        verifyRenderContext,
+      );
       const isObject =
         expectedValue !== null && typeof expectedValue === 'object';
       try {

--- a/src/scenarios/dependencies.spec.ts
+++ b/src/scenarios/dependencies.spec.ts
@@ -1,0 +1,137 @@
+import { collectStepRefs } from './dependencies.js';
+import type { Scenario } from './generated.js';
+
+function makeScenario(steps: Record<string, any>): Scenario {
+  return { steps } as Scenario;
+}
+
+describe('collectStepRefs', () => {
+  // Steps that the `target` step under test can reference; always present so each case only defines its own `target`.
+  const DEPENDENCY_STEPS = {
+    first: { call: { name: 'Step' } },
+    second: { call: { name: 'Step' } },
+    third: { call: { name: 'Step' } },
+  };
+
+  it.each([
+    {
+      name: 'output and configuration references from step arguments',
+      args: {
+        fromOutput: "${ output('first').body }",
+        fromConfig: "${ configuration('a.b') }",
+      },
+      expectedDeps: ['first'],
+      expectedConfigs: ['a.b'],
+    },
+    {
+      name: 'a reference even when a builtin is applied to a member access on it',
+      args: { value: "${ str(output('first').body) }" },
+      expectedDeps: ['first'],
+    },
+    {
+      name: 'references from multiple interpolations in a single string',
+      args: {
+        value:
+          "${ str(output('first')[0].id) }-${ output('second') }${ configuration('a.b') }",
+      },
+      expectedDeps: ['first', 'second'],
+      expectedConfigs: ['a.b'],
+    },
+    {
+      name: 'references nested in array arguments',
+      args: { list: ["${ output('first') }", "${ output('second').id }"] },
+      expectedDeps: ['first', 'second'],
+    },
+    {
+      name: 'references from both branches of a json-e operator',
+      args: {
+        value: {
+          $if: "output('first').ready",
+          then: "${ output('second') }",
+          else: "${ output('third') }",
+        },
+      },
+      expectedDeps: ['first', 'second', 'third'],
+    },
+    {
+      name: 'no references from a plain string that merely mentions output',
+      args: { description: "this step mirrors output('first') by hand" },
+      expectedDeps: [],
+    },
+    {
+      name: 'references from the condition keys of a $switch',
+      args: {
+        value: {
+          $switch: {
+            "output('first').ready": "${ output('second') }",
+            $default: "${ output('third') }",
+          },
+        },
+      },
+      expectedDeps: ['first', 'second', 'third'],
+    },
+    {
+      name: 'references from expectations and explicit dependencies',
+      expectations: [
+        {
+          actual: "${ str(output('first').count) }",
+          value: "${ output('second').value }",
+        },
+      ],
+      after: ['third'],
+      expectedDeps: ['first', 'second', 'third'],
+    },
+    {
+      name: 'references from merged default call arguments',
+      defaultCallArgs: { Target: { value: "${ output('first') }" } },
+      expectedDeps: ['first'],
+    },
+  ])(
+    'collects $name',
+    ({
+      args,
+      expectations,
+      after,
+      defaultCallArgs,
+      expectedDeps,
+      expectedConfigs = [],
+    }) => {
+      const scenario = {
+        defaultCallArgs,
+        steps: {
+          ...DEPENDENCY_STEPS,
+          target: { call: { name: 'Target', args }, expectations, after },
+        },
+      } as unknown as Scenario;
+
+      const { stepDeps, allConfigPaths } = collectStepRefs(scenario);
+
+      expect([...stepDeps.target]).toIncludeSameMembers(expectedDeps);
+      expect([...allConfigPaths]).toIncludeSameMembers(expectedConfigs);
+    },
+  );
+
+  it('throws when a step references its own output in its arguments', () => {
+    const scenario = makeScenario({
+      target: {
+        call: { name: 'Target', args: { value: "${ output('target') }" } },
+      },
+    });
+
+    expect(() => collectStepRefs(scenario)).toThrow(
+      "Step 'target' references its own output in its arguments.",
+    );
+  });
+
+  it('throws when a step references an unknown step', () => {
+    const scenario = makeScenario({
+      target: {
+        call: { name: 'Target', args: { value: "${ output('missing') }" } },
+      },
+    });
+
+    expect(() => collectStepRefs(scenario)).toThrow(
+      "Step 'target' references unknown step 'missing'.",
+    );
+  });
+});

--- a/src/scenarios/dependencies.ts
+++ b/src/scenarios/dependencies.ts
@@ -1,42 +1,101 @@
-import jsone from 'json-e';
 import type { Scenario } from './index.js';
 
 /**
- * Builds a permissive proxy that absorbs arbitrary property accesses and function calls, returning another proxy
- * recursively. Used as a placeholder value during dependency detection so json-e expressions like
- * `${ output('x').body.id }` evaluate without throwing.
+ * The object keys json-e recognizes as operators, mirroring its `operators` table (json-e 4.8).
  */
-function makeSpyValue(): any {
-  const target: any = function () {};
-  return new Proxy(target, {
-    get(_, prop) {
-      if (prop === Symbol.toPrimitive) {
-        return () => '';
-      }
+const JSONE_OPERATORS = new Set([
+  '$eval',
+  '$find',
+  '$flatten',
+  '$flattenDeep',
+  '$fromNow',
+  '$if',
+  '$json',
+  '$let',
+  '$map',
+  '$match',
+  '$merge',
+  '$mergeDeep',
+  '$reduce',
+  '$reverse',
+  '$sort',
+  '$switch',
+]);
 
-      if (prop === 'toString') {
-        return () => '';
-      }
+/**
+ * The json-e operators whose operand is a map keyed by condition expressions (`{ "<condition>": <result>, ... }`).
+ */
+const CONDITION_OPERATORS = new Set(['$match', '$switch']);
 
-      return makeSpyValue();
-    },
-    apply() {
-      return makeSpyValue();
-    },
-  });
+/**
+ * Matches an `output('<id>')` or `configuration('<path>')` call with a string-literal argument.
+ */
+const REFERENCE = /(?<![\w.])(output|configuration)\s*\(\s*(['"])(.*?)\2\s*\)/g;
+
+/**
+ * Extracts the contents of each `${ ... }` interpolation from a template string, respecting `$${` escapes and quoted
+ * substrings so that braces inside string literals do not end an expression early.
+ *
+ * @param template The string to scan.
+ * @returns The expression source of each interpolation, in order.
+ */
+function extractInterpolations(template: string): string[] {
+  const expressions: string[] = [];
+
+  for (let i = 0; i < template.length; i++) {
+    // An interpolation starts at `${`, unless it is an escaped `$${`.
+    if (
+      !(
+        template[i] === '$' &&
+        template[i + 1] === '{' &&
+        template[i - 1] !== '$'
+      )
+    ) {
+      continue;
+    }
+
+    let depth = 1;
+    let quote: string | null = null;
+    let j = i + 2;
+    for (; j < template.length && depth > 0; j++) {
+      const char = template[j];
+      if (quote !== null) {
+        if (char === '\\') {
+          j++;
+        } else if (char === quote) {
+          quote = null;
+        }
+      } else if (char === "'" || char === '"') {
+        quote = char;
+      } else if (char === '{') {
+        depth++;
+      } else if (char === '}') {
+        depth--;
+      }
+    }
+
+    if (depth === 0) {
+      expressions.push(template.slice(i + 2, j - 1));
+      i = j - 1;
+    }
+  }
+
+  return expressions;
 }
 
 /**
- * Detects which step outputs and configuration paths are referenced by `args` by rendering it through json-e with a
- * spy context that records every `output('<id>')` and `configuration('<path>')` call. The spy returns a permissive
- * value, so member accesses and chained calls in templates do not break detection. Errors raised by json-e are
- * swallowed: references collected up to the error are still returned, which is sufficient since unresolved references
- * will surface again at actual rendering time.
+ * Detects which step outputs and configuration paths are referenced by `args` by scanning its expressions for
+ * `output('<id>')` and `configuration('<path>')` calls.
+ *
+ * References can occur in only two places, and detection scans exactly those (which keeps a plain string value that
+ * merely mentions `output('x')` in prose from being mistaken for a reference):
+ * - Inside a `${ ... }` interpolation in any string.
+ * - In the raw expression of a json-e operator — e.g. an `$if` condition or an `$eval`.
  *
  * @param args The (potentially nested) value to scan for references.
  * @returns The set of output IDs and configuration paths referenced in `args`.
  */
-function findRefs(args: any): {
+function findRefs(args: unknown): {
   /**
    * The IDs of the step outputs referenced in `args`, from expressions like `${ output('<id>') }`.
    */
@@ -49,31 +108,49 @@ function findRefs(args: any): {
 } {
   const outputs = new Set<string>();
   const configurations = new Set<string>();
-  if (args === undefined || args === null) {
-    return { outputs, configurations };
-  }
 
-  try {
-    jsone(args, {
-      input: () => makeSpyValue(),
-      output: (id: string) => {
-        if (typeof id === 'string') {
-          outputs.add(id);
-        }
+  const scan = (expression: string) =>
+    expression
+      .matchAll(REFERENCE)
+      .forEach(([, name, , reference]) =>
+        (name === 'output' ? outputs : configurations).add(reference),
+      );
 
-        return makeSpyValue();
-      },
-      configuration: (path: string) => {
-        if (typeof path === 'string') {
-          configurations.add(path);
-        }
+  const visit = (value: unknown) => {
+    if (typeof value === 'string') {
+      extractInterpolations(value).forEach(scan);
+      return;
+    }
 
-        return makeSpyValue();
-      },
-    });
-  } catch {
-    // Partial detection is acceptable; rendering will fail loudly later if a ref is missed.
-  }
+    if (value === null || typeof value !== 'object') {
+      return;
+    }
+
+    Object.values(value).forEach(visit);
+
+    if (Array.isArray(value)) {
+      return;
+    }
+
+    for (const [key, nested] of Object.entries(value)) {
+      // A json-e operator's own value is a raw expression (e.g. an `$if` condition), so scan it as a whole.
+      if (JSONE_OPERATORS.has(key) && typeof nested === 'string') {
+        scan(nested);
+      }
+
+      // `$match` / `$switch` carry their condition expressions as the keys of their operand map (`$default` aside).
+      if (
+        CONDITION_OPERATORS.has(key) &&
+        nested !== null &&
+        typeof nested === 'object' &&
+        !Array.isArray(nested)
+      ) {
+        Object.keys(nested).forEach(scan);
+      }
+    }
+  };
+
+  visit(args);
 
   return { outputs, configurations };
 }

--- a/src/scenarios/generated.ts
+++ b/src/scenarios/generated.ts
@@ -20,9 +20,15 @@ import {
 export type ExpectationActual = string | Record<string, any>;
 
 /**
- * The expected value. May contain `${ match(...) }` and `${ output(...) }` templates.
+ * The expected value. May be any JSON value supported by json-e / JavaScript (string, number, boolean, object, array, or null), and may contain `${ output(...) }` templates.
  */
-export type ExpectationValue = string | Record<string, any>;
+export type ExpectationValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ExpectationValue[]
+  | Record<string, any>;
 
 /**
  * Configuration for a single retry policy (number of attempts and delay between them).
@@ -137,7 +143,7 @@ export class StepExpectation {
   readonly actual?: ExpectationActual;
 
   /**
-   * The expected value. May contain `${ match(...) }` and `${ output(...) }` templates.
+   * The expected value. May be any JSON value supported by json-e / JavaScript (string, number, boolean, object, array, or null), and may contain `${ output(...) }` templates.
    */
   @Allow()
   readonly value!: ExpectationValue;

--- a/src/scenarios/schemas/scenario.yaml
+++ b/src/scenarios/schemas/scenario.yaml
@@ -127,11 +127,23 @@ $defs:
         description: The value to match against. May be a templatable expression. Defaults to the output of the current step.
 
       value:
-        title: ExpectationValue
         oneOf:
-          - type: string
-          - type: object
-        description: The expected value. May contain `${ match(...) }` and `${ output(...) }` templates.
+          - $ref: '#/$defs/ExpectationValue'
+        description: The expected value. May be any JSON value supported by json-e / JavaScript (string, number, boolean, object, array, or null), and may contain `${ output(...) }` templates.
+
+  ExpectationValue:
+    title: ExpectationValue
+    description: The expected value. May be any JSON value supported by json-e / JavaScript (string, number, boolean, object, array, or null), and may contain `${ output(...) }` templates.
+    oneOf:
+      - type: string
+      - type: number
+      - type: boolean
+      - type: 'null'
+      - type: array
+        items:
+          $ref: '#/$defs/ExpectationValue'
+      - type: object
+        additionalProperties: true
 
   ScenarioStep:
     title: ScenarioStep


### PR DESCRIPTION
### 📝 Description of the PR

This PR brings several improvements to scenarios and the `HttpMakeRequest` workspace function. Scenario templates now expose a `rand` function for generating random values — `rand('uuid')`, `rand('int', min, max)`, and `rand('float', min, max)` — and a step expectation `value` may now be any JSON value (string, number, boolean, object, array, or null) rather than only strings or objects. Cross-step dependency detection has also been reworked to scan templates for `output(...)` and `configuration(...)` references instead of evaluating them, so dependencies are now detected correctly across all json-e expression forms, including member access, indexing, builtins, both branches of `$if`/`$switch`, and several interpolations within a single string.

`HttpMakeRequest` gains support for `multipart/form-data` bodies: when the `Content-Type` header is `multipart/form-data`, the `body` object is sent as a form, with fields that can be plain strings, inline file parts, or local files resolved from the workspace root. Additionally, the body is now JSON-serialized whenever the `Content-Type` header is set to `application/json`, even if it is already a string. Finally, the Causa modules used by the project have been upgraded.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
