### PR TITLE
✨ Recognize entityMutationFrom and entityPropertyChanges Causa extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 - Add the `rand` function to scenario templates, generating a random UUID (`rand('uuid')`), integer (`rand('int', min, max)`), or floating-point number (`rand('float', min, max)`).
 - Support `multipart/form-data` bodies in `HttpMakeRequest`: when the `Content-Type` header is `multipart/form-data`, the `body` object is sent as a form.
 - JSON-serialize the `HttpMakeRequest` body (even when it is a string) when the `Content-Type` header is set to `application/json`.
+- Recognize the `entityMutationFrom` (a list of schema references, possibly containing `null` entries) and `entityPropertyChanges` (a list of property names) Causa extensions during JSONSchema parsing. References in `entityMutationFrom` are normalized to absolute paths like other ref-bearing extensions.
 
 Fixes:
 

--- a/src/definitions/model.types.ts
+++ b/src/definitions/model.types.ts
@@ -38,6 +38,11 @@ export type CausaExtensions = {
    */
   entityMutationFrom?: (string | null)[];
 
+  /**
+   * Names of the entity properties changed by this mutation (event constraint).
+   */
+  entityPropertyChanges?: string[];
+
   [key: string]: unknown;
 };
 

--- a/src/definitions/model.types.ts
+++ b/src/definitions/model.types.ts
@@ -32,6 +32,12 @@ export type CausaExtensions = {
    */
   enumHint?: string;
 
+  /**
+   * Absolute paths of the schemas that define the constraints an entity must satisfy for this event constraint to
+   * apply. A `null` entry denotes an absent prior state (e.g. a creation mutation).
+   */
+  entityMutationFrom?: (string | null)[];
+
   [key: string]: unknown;
 };
 
@@ -44,6 +50,7 @@ export type CausaExtensions = {
 export const REF_BEARING_CAUSA_EXTENSIONS: readonly string[] = [
   'constraintFor',
   'enumHint',
+  'entityMutationFrom',
 ];
 
 /**

--- a/src/jsonschema/loader.spec.ts
+++ b/src/jsonschema/loader.spec.ts
@@ -66,8 +66,10 @@ properties:
 title: Root
 type: object
 causa:
-  constraintFor: "./other.yaml"`,
+  constraintFor: "./other.yaml"
+  entityMutationFrom: ["./mutation.yaml", null]`,
       '/abs/other.yaml': 'title: Other\ntype: object',
+      '/abs/mutation.yaml': 'title: Mutation\ntype: object',
     };
 
     const { schemas } = await loadSchemas(['/abs/root.yaml'], {
@@ -75,6 +77,7 @@ causa:
     });
 
     expect(schemas['/abs/other.yaml']).toMatchObject({ name: 'Other' });
+    expect(schemas['/abs/mutation.yaml']).toMatchObject({ name: 'Mutation' });
   });
 
   it('should record per-file errors instead of aborting', async () => {

--- a/src/jsonschema/loader.ts
+++ b/src/jsonschema/loader.ts
@@ -143,6 +143,12 @@ function* refsFromExtensions(extensions: CausaExtensions): Generator<string> {
     const value = extensions[key];
     if (typeof value === 'string') {
       yield value;
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string') {
+          yield item;
+        }
+      }
     }
   }
 }

--- a/src/jsonschema/parser.spec.ts
+++ b/src/jsonschema/parser.spec.ts
@@ -1292,12 +1292,14 @@ title: U
 type: object
 causa:
   constraintFor: "./other.yaml#/$defs/Foo"
+  entityMutationFrom: ["./other.yaml#/$defs/Bar", null]
   custom: untouched`,
         path,
       );
 
       expect(schema.extensions).toEqual({
         constraintFor: '/abs/other.yaml#/$defs/Foo',
+        entityMutationFrom: ['/abs/other.yaml#/$defs/Bar', null],
         custom: 'untouched',
       });
     });

--- a/src/jsonschema/parser.ts
+++ b/src/jsonschema/parser.ts
@@ -757,12 +757,18 @@ function buildExtensions(raw: unknown, path: string): CausaExtensions {
 
   return Object.fromEntries(
     Object.entries(raw).map(([key, value]) => {
-      return [
-        key,
-        REF_BEARING_CAUSA_EXTENSIONS.includes(key) && typeof value === 'string'
-          ? resolveRef(value, path)
-          : value,
-      ];
+      if (!REF_BEARING_CAUSA_EXTENSIONS.includes(key)) {
+        return [key, value];
+      }
+
+      if (Array.isArray(value)) {
+        return [
+          key,
+          value.map((i) => (typeof i === 'string' ? resolveRef(i, path) : i)),
+        ];
+      }
+
+      return [key, typeof value === 'string' ? resolveRef(value, path) : value];
     }),
   );
 }

--- a/src/jsonschema/writer.spec.ts
+++ b/src/jsonschema/writer.spec.ts
@@ -246,7 +246,10 @@ describe('apply', () => {
       path: filePath,
       properties: [],
       additionalProperties: false,
-      extensions: { constraintFor: '/abs/other.yaml#/$defs/Foo' },
+      extensions: {
+        constraintFor: '/abs/other.yaml#/$defs/Foo',
+        entityMutationFrom: ['/abs/other.yaml#/$defs/Bar', null],
+      },
       databases: [],
     };
 
@@ -255,6 +258,7 @@ describe('apply', () => {
     const parsed = yaml.parse(out);
     expect(parsed.causa).toEqual({
       constraintFor: 'other.yaml#/$defs/Foo',
+      entityMutationFrom: ['other.yaml#/$defs/Bar', null],
     });
   });
 

--- a/src/jsonschema/writer.ts
+++ b/src/jsonschema/writer.ts
@@ -384,12 +384,25 @@ function applyExtensions(
   }
 
   const value = Object.fromEntries(
-    entries.map(([key, val]) => [
-      key,
-      REF_BEARING_CAUSA_EXTENSIONS.includes(key) && typeof val === 'string'
-        ? toRelativeRef(val, filePath)
-        : val,
-    ]),
+    entries.map(([key, val]) => {
+      if (!REF_BEARING_CAUSA_EXTENSIONS.includes(key)) {
+        return [key, val];
+      }
+
+      if (Array.isArray(val)) {
+        return [
+          key,
+          val.map((item) =>
+            typeof item === 'string' ? toRelativeRef(item, filePath) : item,
+          ),
+        ];
+      }
+
+      return [
+        key,
+        typeof val === 'string' ? toRelativeRef(val, filePath) : val,
+      ];
+    }),
   );
 
   applyMinimalChange(node, { causa: value });


### PR DESCRIPTION
### 📝 Description of the PR

This PR adds two known Causa extensions to JSONSchema parsing, both used to describe how an event mutates an entity. `entityMutationFrom` is a list of references to the schemas defining the constraints a prior entity state must satisfy for the mutation to apply, where a `null` entry denotes an absent prior state (e.g. a creation). Like the other ref-bearing extensions, its references are normalized to absolute paths during parsing and rewritten to relative form on writing, and the loader follows them transitively. `entityPropertyChanges` is a plain list of property names changed by the mutation and is passed through unchanged.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.