### PR TITLE
🐛 Close the backfill source iterator if the publisher does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 🔖 Changelog
 
+## Unreleased
+
+Fixes:
+
+- Close the backfill event source iterator once publishing is done even when the publisher fails before consuming it, never iterates it, or stops part-way.
+
 ## v0.35.0-beta.7 (2026-06-08)
 
 Features:

--- a/src/functions/event-topic/backfill.spec.ts
+++ b/src/functions/event-topic/backfill.spec.ts
@@ -9,6 +9,7 @@ import { jest } from '@jest/globals';
 import { access, mkdtemp, readFile, rm } from 'fs/promises';
 import 'jest-extended';
 import { join, resolve } from 'path';
+import { Readable } from 'stream';
 import {
   type BackfillEvent,
   EventTopicBackfill,
@@ -35,6 +36,9 @@ describe('EventTopicBackfillForAll', () => {
   let waitForProcessingMock: WorkspaceFunctionCallMock<EventTopicBrokerWaitForProcessing>;
   let cleanBackfillMock: WorkspaceFunctionCallMock<EventTopicCleanBackfill>;
   let backfillSource: AsyncIterable<BackfillEvent>;
+  let sourceReturnMock: jest.Mock<
+    NonNullable<AsyncIterator<BackfillEvent>['return']>
+  >;
 
   async function fileExists(path: string): Promise<boolean> {
     try {
@@ -79,7 +83,12 @@ describe('EventTopicBackfillForAll', () => {
       EventTopicBrokerPublishEvents,
       () => Promise.resolve(),
     );
-    backfillSource = (async function* () {})();
+    sourceReturnMock = jest.fn(async () => ({ done: true, value: undefined }));
+    const sourceIterator: AsyncIterator<BackfillEvent> = {
+      next: async () => ({ done: true, value: undefined }),
+      return: sourceReturnMock,
+    };
+    backfillSource = { [Symbol.asyncIterator]: () => sourceIterator };
     createBackfillSourceMock = registerMockFunction(
       functionRegistry,
       EventTopicCreateBackfillSource,
@@ -125,10 +134,21 @@ describe('EventTopicBackfillForAll', () => {
     });
     expect(waitForProcessingMock).not.toHaveBeenCalled();
     expect(cleanBackfillMock).not.toHaveBeenCalled();
+    expect(sourceReturnMock).toHaveBeenCalledOnce();
   });
 
   it('should use an existing topic, create triggers, and publish events', async () => {
     const expectedFile = resolve(tmpDir, 'backfill.json');
+    const event: BackfillEvent = { data: Buffer.from('🌊') };
+    createBackfillSourceMock.mockImplementation(async () =>
+      Readable.from([event]),
+    );
+    const publishedEvents: BackfillEvent[] = [];
+    publishEventsMock.mockImplementation(async (_, { source }) => {
+      for await (const published of source()) {
+        publishedEvents.push(published);
+      }
+    });
 
     const actualFile = await context.call(EventTopicBackfill, {
       eventTopic: 'test-topic',
@@ -163,7 +183,7 @@ describe('EventTopicBackfillForAll', () => {
       eventTopic: 'test-topic',
       source: expect.any(Function),
     });
-    expect(publishEventsMock.mock.calls[0][1].source()).toBe(backfillSource);
+    expect(publishedEvents).toEqual([event]);
     const actualBackfillId = createTriggerMock.mock.calls[0][1].backfillId;
     const actualFileContent = await readFile(actualFile);
     expect(JSON.parse(actualFileContent.toString())).toEqual({
@@ -296,6 +316,7 @@ describe('EventTopicBackfillForAll', () => {
       source: expect.any(Function),
     });
     expect(await fileExists(expectedFile)).toBe(false);
+    expect(sourceReturnMock).toHaveBeenCalledOnce();
   });
 
   it('should write the backfill file when publishing fails with temporary resources', async () => {
@@ -319,6 +340,18 @@ describe('EventTopicBackfillForAll', () => {
         `backfill/${actualBackfillId}/broker/test-topic/trigger/trigger1`,
       ],
     });
+  });
+
+  it('should not fail the backfill when closing the source iterator throws', async () => {
+    sourceReturnMock.mockRejectedValue(new Error('💥 close'));
+
+    const actualFile = await context.call(EventTopicBackfill, {
+      eventTopic: 'test-topic',
+    });
+
+    expect(actualFile).toBe('');
+    expect(publishEventsMock).toHaveBeenCalledOnce();
+    expect(sourceReturnMock).toHaveBeenCalledOnce();
   });
 
   it('should clone the context and forward a structured trigger for project-scoped triggers', async () => {

--- a/src/functions/event-topic/backfill.ts
+++ b/src/functions/event-topic/backfill.ts
@@ -195,6 +195,9 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
 
     let hasTempResources = false;
     let publishFailed = false;
+    // The source iterable is created eagerly and may hold an open resource.
+    // This guarantees cleanup even if the publisher throws before consuming it, never iterates it, or stops part-way.
+    let closeSource: (() => Promise<unknown>) | undefined;
     try {
       await this.createTriggers(backfillId, topicId, temporaryData);
 
@@ -206,11 +209,13 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
           filter: this.filter,
         },
       );
+      const sourceIterator = eventsSource[Symbol.asyncIterator]();
+      closeSource = sourceIterator.return?.bind(sourceIterator);
 
       await this._context.call(EventTopicBrokerPublishEvents, {
         topicId,
         eventTopic: this.eventTopic,
-        source: () => eventsSource,
+        source: () => ({ [Symbol.asyncIterator]: () => sourceIterator }),
       });
 
       this._context.logger.info('✅ Successfully published all events.');
@@ -218,6 +223,14 @@ export class EventTopicBackfillForAll extends EventTopicBackfill {
       publishFailed = true;
       throw error;
     } finally {
+      try {
+        await closeSource?.();
+      } catch (error) {
+        this._context.logger.warn(
+          `⚠️ Failed to close the backfill event source: ${error}.`,
+        );
+      }
+
       hasTempResources =
         !!temporaryData.temporaryTopicId ||
         temporaryData.temporaryTriggerResourceIds.length > 0;


### PR DESCRIPTION
### 📝 Description of the PR

The generic backfill logic (`EventTopicBackfillForAll`) creates the event source eagerly as an async iterable and hands it to `EventTopicBrokerPublishEvents` for consumption. Because that iterable may hold an open resource (a file handle, database cursor, or network connection), it must be released once the backfill is over. Previously, closing it was left entirely to the publisher, so if the publisher failed before consuming the source, never iterated it, or stopped part-way, the iterator could be left open — potentially leaving the underlying producer suspended on a promise that never settles.

The backfill now keeps ownership of the source's lifecycle: it obtains a single iterator, shares it with the publisher, and always closes it once publishing is done, regardless of how the publishing ends. Closing errors are logged rather than propagated, so they never mask the actual outcome of the backfill.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
