### PR TITLE
🔖 Prepare v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v1.0.0 (2026-06-09)
+
+This release includes all the changes from the `v0.35.0-beta.*` version.
+
 Fixes:
 
 - Close the backfill event source iterator once publishing is done even when the publisher fails before consuming it, never iterates it, or stops part-way.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.35.0-beta.7",
       "license": "ISC",
       "dependencies": {
-        "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",
-        "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",
-        "@scalar/json-magic": "^0.12.14",
-        "@scalar/openapi-parser": "^0.28.5",
+        "@causa/cli": "^1.0.0",
+        "@causa/workspace": "^1.0.0",
+        "@scalar/json-magic": "^0.12.15",
+        "@scalar/openapi-parser": "^0.28.6",
         "ajv": "^8.20.0",
         "class-validator": "^0.15.1",
         "expect": "^30.4.1",
@@ -23,23 +23,23 @@
         "yaml": "^2.9.0"
       },
       "devDependencies": {
-        "@scalar/openapi-types": "^0.9.0",
+        "@scalar/openapi-types": "^0.9.1",
         "@swc/core": "^1.15.40",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/jest": "^30.0.0",
         "@types/json-schema": "^7.0.15",
         "@types/micromatch": "^4.0.10",
-        "@types/node": "^20.19.41",
-        "eslint": "^10.4.0",
+        "@types/node": "^20.19.42",
+        "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-prettier": "^5.5.6",
         "jest": "^30.4.2",
         "jest-extended": "^7.0.0",
         "nock": "^14.0.15",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.60.0"
+        "typescript-eslint": "^8.61.0"
       },
       "engines": {
         "node": ">=22"
@@ -560,13 +560,13 @@
       "license": "MIT"
     },
     "node_modules/@causa/cli": {
-      "version": "0.8.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@causa/cli/-/cli-0.8.0-beta.1.tgz",
-      "integrity": "sha512-6M2kyR4iQKPHhtd7a0ZYb7yAHt5Vp8M0/dHyM1jDh1Hi4nUqBnwBirOQsG9N0X9mY7VO0+VOqlR3+B4faWiliQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@causa/cli/-/cli-1.0.0.tgz",
+      "integrity": "sha512-ruGylC6W8tcmAgiGqPUBH8CxgsFfIsTrN0Um8c0e5euZu/Mi7OQdu1r8Efcf8OCfCrcsSyqqff316GcwGalzYw==",
       "license": "ISC",
       "dependencies": {
-        "@causa/workspace": ">= 0.25.0-beta.1 < 1.0.0",
-        "commander": "^14.0.3",
+        "@causa/workspace": "^1.0.0",
+        "commander": "^15.0.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "reflect-metadata": "^0.2.2"
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@causa/workspace": {
-      "version": "0.25.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-0.25.0-beta.3.tgz",
-      "integrity": "sha512-UEqZYgO9ZTkeuP7fOzspknZTd46HZsIhAgGU0TPqed6vWzWP+swhK/4vp4OdTDWjNjKS/LudJc89YHTop1ZNMQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-1.0.0.tgz",
+      "integrity": "sha512-GELvGct2UF9wB0neXLmNOUD78EqdbfIIFK4KiQRT3h73VOmAdNedT3q+YjdOwcstp9gR5xIDCwS27JLprXXIWQ==",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",
@@ -591,7 +591,7 @@
         "lodash-es": "^4.18.1",
         "pino": "^10.3.1",
         "resolve-package-path": "^4.0.3",
-        "semver": "^7.8.0",
+        "semver": "^7.8.3",
         "yaml": "^2.9.0"
       },
       "engines": {
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1469,34 +1469,34 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.0.tgz",
-      "integrity": "sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.1.tgz",
+      "integrity": "sha512-yuiuBCadP5bjAnIv23QvifVN/NaMi9xBF6b8Wdk4QOzwzLPJmp699MAdf33J0A5i2qKcvnu32iz/VkEJmQRe5g==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.12.14",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.14.tgz",
-      "integrity": "sha512-dWrCy3ew1r7OQ1pu2r4ZjiKEVy0yVd66kXdmsl41bteOG2F2I2IBlPjmPV6p8ckjImQHxtNBIntFaQfNrdBhJg==",
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.15.tgz",
+      "integrity": "sha512-ZYgdYZ0jSZXQeyhG2lJ20FjzvKsaDRXk4bPguF/Ytl2nGBh9a6RIIr9NvVy4zAD67a/ahm+xipXlfoR1KtB5fg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.0",
+        "@scalar/helpers": "0.8.1",
         "pathe": "^2.0.3",
         "yaml": "^2.8.3"
       },
@@ -1505,15 +1505,15 @@
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.5.tgz",
-      "integrity": "sha512-W8uS5p4dR5Ri4Zqra6c/KaL54R5qkLJAwXCm/QTYvzsLw/NT4N6NdbqHQLHpJeLMG9c0dkA70S/KZKkFZgDRTg==",
+      "version": "0.28.6",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.6.tgz",
+      "integrity": "sha512-gCl4r+rpmO+CKfwmmwI+GJVFhuNut7e6beUcD/xazanH4epkLT7V9ZgMv9YKbUBE73fkrOv6NJympeEGiU8aUw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.0",
-        "@scalar/json-magic": "0.12.14",
-        "@scalar/openapi-types": "0.9.0",
-        "@scalar/openapi-upgrader": "0.2.8",
+        "@scalar/helpers": "0.8.1",
+        "@scalar/json-magic": "0.12.15",
+        "@scalar/openapi-types": "0.9.1",
+        "@scalar/openapi-upgrader": "0.2.9",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
@@ -1526,21 +1526,21 @@
       }
     },
     "node_modules/@scalar/openapi-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.9.0.tgz",
-      "integrity": "sha512-XGuYegItO8iJbEy5hHxS04vyxoFIuERy3D/twt1hGPya6KJljg9iO0geZ/X5vjDKmSKYAuMNkGqYO5Jjp4NLUA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.9.1.tgz",
+      "integrity": "sha512-gkGhSkxSzADaBiNg+ZAbJuwj+ZUmzP2Pg9CWZ7ZP+0fck2WjPeDDM7aAbouAm0aQQMF9xBjSPXSA9a/qTHYaTw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/openapi-upgrader": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.8.tgz",
-      "integrity": "sha512-/SDb3+SIFuScKwrNRTFd7bklGDkayo81cHZlajXfUaT22Oc4VUlOUvyMXBLPa0miOfZTExYTM1I0BWW7Nujugw==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.2.9.tgz",
+      "integrity": "sha512-D5b0rGLLZgmkO9mdW2j/ND1KBlH1u3RCpr87HPxv9P9ZSr6PtM5iLqFOJq0ACiaHjY2mikCrxgDmnUEhTzRpHQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/openapi-types": "0.9.0"
+        "@scalar/openapi-types": "0.9.1"
       },
       "engines": {
         "node": ">=22"
@@ -2025,9 +2025,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2061,17 +2061,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/type-utils": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2084,7 +2084,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.0",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2100,16 +2100,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2125,14 +2125,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.0",
-        "@typescript-eslint/types": "^8.60.0",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2147,14 +2147,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2182,15 +2182,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2207,9 +2207,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2221,16 +2221,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.0",
-        "@typescript-eslint/tsconfig-utils": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2249,16 +2249,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2273,13 +2273,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2920,9 +2920,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3029,9 +3029,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {
@@ -3235,12 +3235,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -3349,9 +3349,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "version": "1.5.369",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.369.tgz",
+      "integrity": "sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==",
       "dev": true,
       "license": "ISC"
     },
@@ -3418,9 +3418,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3429,7 +3429,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3490,14 +3490,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
+        "synckit": "^0.11.13"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -5165,9 +5165,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.3.tgz",
-      "integrity": "sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -5374,9 +5374,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5949,9 +5949,9 @@
     },
     "node_modules/react-is-19": {
       "name": "react-is",
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/real-require": {
@@ -6072,9 +6072,9 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6147,9 +6147,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6467,13 +6467,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -6569,9 +6569,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6676,16 +6676,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
-      "integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.0",
-        "@typescript-eslint/parser": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0"
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.7",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "0.35.0-beta.7",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "generateConfigurationSchemas": "cs model genCode && perl -pi -e 's|\\@causa/runtime|\\@causa/workspace/validation|g' src/configurations/generated.ts src/scenarios/generated.ts"
   },
   "dependencies": {
-    "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",
-    "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",
-    "@scalar/json-magic": "^0.12.14",
-    "@scalar/openapi-parser": "^0.28.5",
+    "@causa/cli": "^1.0.0",
+    "@causa/workspace": "^1.0.0",
+    "@scalar/json-magic": "^0.12.15",
+    "@scalar/openapi-parser": "^0.28.6",
     "ajv": "^8.20.0",
     "class-validator": "^0.15.1",
     "expect": "^30.4.1",
@@ -50,22 +50,22 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@scalar/openapi-types": "^0.9.0",
+    "@scalar/openapi-types": "^0.9.1",
     "@swc/core": "^1.15.40",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^30.0.0",
     "@types/json-schema": "^7.0.15",
     "@types/micromatch": "^4.0.10",
-    "@types/node": "^20.19.41",
-    "eslint": "^10.4.0",
+    "@types/node": "^20.19.42",
+    "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-prettier": "^5.5.6",
     "jest": "^30.4.2",
     "jest-extended": "^7.0.0",
     "nock": "^14.0.15",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.60.0"
+    "typescript-eslint": "^8.61.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "0.35.0-beta.7",
+  "version": "1.0.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Breaking changes:

- Remove the `key` (ordering) property from `BackfillEvent`.
- Remove the `quicktype`-based code generation, including the `./code-generation` subpath export, the `MakeGeneratorQuicktypeInputData` workspace function, and the `quicktype-core` dependency.
- `cs events backfill` no longer writes a backfill file when no temporary resources were created (e.g. no temporary topic and no triggers, or when the command fails before any temporary resource exists). In that case, the command returns an empty string instead of a path, and its output is suppressed.

Features:

- Define the format-neutral schema model types (`Schema`, `ObjectSchema`, `EnumSchema`, `UnionSchema`, `Property`, `PropertyType`, `SchemaDatabase`, `CausaExtensions`, `InvalidSchemaError`).
- Define the `ModelSchemaParse`, `ModelSchemaExtractDatabase`, and `ModelSchemaWrite` workspace functions.
- Implement `ModelSchemaParse` and `ModelSchemaWrite` for JSONSchema.
- Export the `./jsonschema` subpath.
- Define the `serviceContainer.healthCheck` configuration for service containers, with `startup` and `liveness` probe blocks supporting `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`.
- Support inline object, enum, and union schemas declared inside a property's `oneOf` (including the nullable wrapper), inside array `items`, and inside `additionalProperties` during JSONSchema parsing.
- Support `type` declared as an array (e.g. `[string, "null"]`, `[string, integer]`) during JSONSchema parsing, both as a nullable wrapper and as a shorthand for a union.
- Infer a schema name from the source path (filename, `$defs`/`definitions` key, or property name) when no `title` is provided during JSONSchema parsing.
- Add the `--autoClean` option to `cs events backfill`, which waits for events to be processed after publishing and runs `cleanBackfill` inline. Introduces the broker-side `EventTopicBrokerWaitForProcessing` workspace function, which implementations should provide to support `--autoClean`.
- Parse the `additionalProperties` declaration on object schemas during JSONSchema parsing, exposing it on `ObjectSchema.additionalProperties` as a boolean or a resolved `PropertyType` (with inline object, enum, and union shapes extracted as nested schemas, like map values).
- Support JSONSchema `anyOf` unions during parsing and writing.
- Support inline object, enum, and union schemas declared as variants of a `oneOf` or `anyOf`.
- Add the `rand` function to scenario templates, generating a random UUID (`rand('uuid')`), integer (`rand('int', min, max)`), or floating-point number (`rand('float', min, max)`).
- Support `multipart/form-data` bodies in `HttpMakeRequest`: when the `Content-Type` header is `multipart/form-data`, the `body` object is sent as a form.
- JSON-serialize the `HttpMakeRequest` body (even when it is a string) when the `Content-Type` header is set to `application/json`.
- Recognize the `entityMutationFrom` (a list of schema references, possibly containing `null` entries) and `entityPropertyChanges` (a list of property names) Causa extensions during JSONSchema parsing. References in `entityMutationFrom` are normalized to absolute paths like other ref-bearing extensions.

Fixes:

- Ignore unsupported JSONSchema `format` values for primitive types rather than throwing, falling back to the bare type.
- Treat a missing `additionalProperties` as `true` (the JSONSchema default) when parsing maps, so that `{ type: object }` with no `properties` resolves to a map of any.
- Detect scenario step dependencies across all `json-e` expression forms, including member access, indexing, builtins, both branches of `$if`/`$switch`, and multiple interpolations in a single string.
- Allow any JSON value (string, number, boolean, object, array, or null) as a scenario step expectation `value`.
- Close the backfill event source iterator once publishing is done even when the publisher fails before consuming it, never iterates it, or stops part-way.

Chores:

- Replace the `js-yaml` dependency with `yaml`.
- Remove the `axios` dependency in favor of the Node.js-provided `fetch`.
- Update configuration schemas for compatibility with new code generation.
