### PR TITLE
🐛 Allow `entityPropertyChanges` to be `*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Allow the `entityPropertyChanges` Causa extension to be `*`, denoting that all entity properties may be changed by the mutation.
+
 ## v1.0.0 (2026-06-09)
 
 This release includes all the changes from the `v0.35.0-beta.*` version.

--- a/src/definitions/model.types.ts
+++ b/src/definitions/model.types.ts
@@ -40,8 +40,9 @@ export type CausaExtensions = {
 
   /**
    * Names of the entity properties changed by this mutation (event constraint).
+   * `*` denotes that all properties may be changed.
    */
-  entityPropertyChanges?: string[];
+  entityPropertyChanges?: string[] | '*';
 
   [key: string]: unknown;
 };


### PR DESCRIPTION
### 📝 Description of the PR

The `entityPropertyChanges` Causa extension can now be set to `*`, in addition to an explicit list of property names. The `*` value denotes that all of an entity's properties may be changed by a mutation, avoiding the need to enumerate every property when a mutation can touch any of them.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.