### PR TITLE
⬆️ Upgrade Causa modules to 1.0.0

### DIFF
--- a/causa.yaml
+++ b/causa.yaml
@@ -11,8 +11,8 @@ project:
 
 causa:
   modules:
-    '@causa/workspace-core': '>= 0.35.0-beta.6'
-    '@causa/workspace-typescript': '>= 0.23.0-beta.4'
+    '@causa/workspace-core': ^1.0.0
+    '@causa/workspace-typescript': ^1.0.0
 
 javascript:
   dependencies:


### PR DESCRIPTION
### 📝 Description of the PR

Updates the required Causa modules (`@causa/workspace-core` and `@causa/workspace-typescript`) to their stable `^1.0.0` releases, replacing the previous beta version constraints.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~