### PR TITLE
✨ Define the dto and enabled properties on service container triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Add the optional `dto` (a schema reference relative to the project's root) and `enabled` (a boolean defaulting to `true`, disabling deployment of the trigger when `false`) properties to generic service container triggers.
+
 ## v1.0.1 (2026-06-09)
 
 Fixes:

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -6,6 +6,7 @@ import {
   Allow,
   Equals,
   IsArray,
+  IsBoolean,
   IsDefined,
   IsIn,
   IsNumber,
@@ -860,6 +861,22 @@ export class ServiceContainerGenericTrigger {
    */
   @IsString()
   readonly type!: string;
+
+  /**
+   * Whether the trigger is active. Defaults to `true`.
+   * If `false`, the trigger shouldn't be deployed.
+   */
+  @AllowMissing()
+  @IsBoolean()
+  readonly enabled?: boolean;
+
+  /**
+   * A reference to a schema, relative to the project's root, that the trigger / endpoint accepts.
+   * Unsupported for `event` triggers, which use the referenced topic's schema.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly dto?: string;
 
   /**
    * The endpoint called by the trigger.

--- a/src/configurations/schemas/service-container.yaml
+++ b/src/configurations/schemas/service-container.yaml
@@ -119,6 +119,18 @@ properties:
                   type: string
                   description: The type of trigger.
 
+                enabled:
+                  type: boolean
+                  description: |-
+                    Whether the trigger is active. Defaults to `true`.
+                    If `false`, the trigger shouldn't be deployed.
+
+                dto:
+                  type: string
+                  description: |-
+                    A reference to a schema, relative to the project's root, that the trigger / endpoint accepts.
+                    Unsupported for `event` triggers, which use the referenced topic's schema.
+
                 endpoint:
                   title: ServiceContainerTriggerEndpoint
                   type: object


### PR DESCRIPTION
### 📝 Description of the PR

Adds two optional properties to the generic service container trigger definition. `dto` references a schema, relative to the project's root, that the trigger / endpoint accepts (unsupported for `event` triggers, which use the referenced topic's schema). `enabled` is a boolean defaulting to `true`; when set to `false`, the trigger is inactive and should not be deployed. Both properties are surfaced on the generated `ServiceContainerGenericTrigger` configuration class.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~