### PR TITLE
🔖 Prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.1.0 (2026-06-11)
+
 Features:
 
 - Add the optional `dto` (a schema reference relative to the project's root) and `enabled` (a boolean defaulting to `true`, disabling deployment of the trigger when `false`) properties to generic service container triggers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Add the optional `dto` (a schema reference relative to the project's root) and `enabled` (a boolean defaulting to `true`, disabling deployment of the trigger when `false`) properties to generic service container triggers.