### PR TITLE
✨ Support OS-level sandboxing for spawned processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Add OS-level sandboxing for spawned processes, backed by `@anthropic-ai/sandbox-runtime`. Sandbox profiles are defined under `causa.sandboxes` and selected through the new `sandbox` option of `ProcessService.spawn` (also exposed by `GitService.git` and `DockerService.docker`).
+
 ## v1.1.0 (2026-06-11)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -77,11 +77,38 @@ This section provides pointers for Causa module developers. Workspace function d
 
 This module implements some [services](./src/services/) used by itself, but which might also come handy in other modules, namely:
 
-- `ProcessService`: Provides a normalized way to spawn child processes.
+- `ProcessService`: Provides a normalized way to spawn child processes, optionally inside an OS-level sandbox (see [Sandboxing](#-sandboxing) below).
 - `GitService`: Runs `git` commands using the `ProcessService`.
 - `DockerService`: Runs `docker` commands using the `ProcessService`.
 - `DockerEmulatorService`: Provides a normalized way to starting and stopping containerized emulators. Also provides a way to wait for an emulator exposing an HTTP endpoint.
 - `ServiceContainerBuilderService`: Provides the base logic to build service container images (using the `DockerService`). Language-specific modules can use this service and customize build parameters.
+
+## 🔒 Sandboxing
+
+The `ProcessService` can run a spawned process inside an OS-level sandbox (macOS Seatbelt or Linux Bubblewrap), powered by [`@anthropic-ai/sandbox-runtime`](https://github.com/anthropics/sandbox-runtime). Sandboxing is opt-in and fails closed: a process runs unsandboxed unless it references a profile, and referencing a missing or invalid profile throws rather than running the process unrestricted.
+
+Sandbox profiles are defined under `causa.sandboxes`, keyed by an arbitrary name:
+
+```yaml
+causa:
+  sandboxes:
+    install:
+      network:
+        allowedDomains: [registry.npmjs.org, '*.npmjs.org']
+      filesystem:
+        allowRead: ['~/.npm']
+        allowWrite: ['~/.npm']
+      credentials:
+        environment:
+          NPM_TOKEN:
+            hosts: [registry.npmjs.org]
+```
+
+A profile controls:
+
+- **Network** (`network`): `allowedDomains` is an allowlist (an empty or omitted list blocks all network access); `deniedDomains` takes precedence over it. Wildcards such as `*.example.com` are supported. Additional flags (`allowLocalBinding`, `allowUnixSockets`, `allowAllUnixSockets`) relax specific restrictions.
+- **Filesystem** (`filesystem`): the workspace root is always readable and writable, and the home directory is always denied for reads. `denyRead`, `allowRead`, `allowWrite`, and `denyWrite` extend those defaults (re-allowed paths take precedence over denied ones).
+- **Credentials** (`credentials.environment`): a map of environment variables, keyed by name, that must not be exposed in clear to the process. Each variable is replaced by an opaque sentinel inside the sandbox. The real value is injected by the host only into requests to the declared `hosts`. An empty `hosts` list denies the variable entirely (it is unset inside the sandbox).
 
 ## 🧱 Infrastructure processors
 

--- a/causa.yaml
+++ b/causa.yaml
@@ -17,7 +17,7 @@ causa:
 javascript:
   dependencies:
     check:
-      allowlist: []
+      allowlist: [GHSA-h67p-54hq-rp68]
     update:
       packageTargets:
         '@types/node': minor

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.59",
         "@causa/cli": "^1.0.0",
-        "@causa/workspace": "^1.0.0",
-        "@scalar/json-magic": "^0.12.15",
-        "@scalar/openapi-parser": "^0.28.6",
+        "@causa/workspace": "^1.0.1",
+        "@scalar/json-magic": "^0.12.16",
+        "@scalar/openapi-parser": "^0.28.7",
         "ajv": "^8.20.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -26,22 +26,22 @@
       },
       "devDependencies": {
         "@scalar/openapi-types": "^0.9.1",
-        "@swc/core": "^1.15.40",
+        "@swc/core": "^1.15.43",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/jest": "^30.0.0",
         "@types/json-schema": "^7.0.15",
         "@types/micromatch": "^4.0.10",
-        "@types/node": "^22.19.21",
-        "eslint": "^10.4.1",
+        "@types/node": "^22.20.0",
+        "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "jest": "^30.4.2",
         "jest-extended": "^7.0.0",
-        "nock": "^14.0.15",
+        "nock": "^14.0.16",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.61.0"
+        "typescript-eslint": "^8.62.0"
       },
       "engines": {
         "node": ">=22"
@@ -64,15 +64,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sandbox-runtime/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -608,10 +599,19 @@
         "node": ">=22"
       }
     },
+    "node_modules/@causa/cli/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@causa/workspace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-1.0.0.tgz",
-      "integrity": "sha512-GELvGct2UF9wB0neXLmNOUD78EqdbfIIFK4KiQRT3h73VOmAdNedT3q+YjdOwcstp9gR5xIDCwS27JLprXXIWQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-1.0.2.tgz",
+      "integrity": "sha512-QNaw67NHMgq1ClpJdcrZCWrvDBTHWUmNEMFR+I23qoYwRlCk6USPgGuaT5kBWK2zK913cAWJU1fQu/U5iBqKDQ==",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",
@@ -621,7 +621,7 @@
         "lodash-es": "^4.18.1",
         "pino": "^10.3.1",
         "resolve-package-path": "^4.0.3",
-        "semver": "^7.8.3",
+        "semver": "^7.8.5",
         "yaml": "^2.9.0"
       },
       "engines": {
@@ -1403,14 +1403,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -1518,21 +1518,21 @@
       "license": "MIT"
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.1.tgz",
-      "integrity": "sha512-yuiuBCadP5bjAnIv23QvifVN/NaMi9xBF6b8Wdk4QOzwzLPJmp699MAdf33J0A5i2qKcvnu32iz/VkEJmQRe5g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.0.tgz",
+      "integrity": "sha512-M34CLRCttqC1bXthI/QSzQj0s5C6nrU2PFWf/vOT3RpycbiGDGQbqR+5RfFzpOIQvRqbHfNdcRbeiZBw+vCbkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.12.15",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.15.tgz",
-      "integrity": "sha512-ZYgdYZ0jSZXQeyhG2lJ20FjzvKsaDRXk4bPguF/Ytl2nGBh9a6RIIr9NvVy4zAD67a/ahm+xipXlfoR1KtB5fg==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.17.tgz",
+      "integrity": "sha512-Vw2nrUDIjhvMP6vxFtkiiFlabJ6SyTtfn1BsOxgnr1hIB+/rkngMguiDzl5em21VjyfFGIoADia+QWKM2hdcdA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.1",
+        "@scalar/helpers": "0.9.0",
         "pathe": "^2.0.3",
         "yaml": "^2.8.3"
       },
@@ -1541,13 +1541,13 @@
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.28.6",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.6.tgz",
-      "integrity": "sha512-gCl4r+rpmO+CKfwmmwI+GJVFhuNut7e6beUcD/xazanH4epkLT7V9ZgMv9YKbUBE73fkrOv6NJympeEGiU8aUw==",
+      "version": "0.28.8",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.8.tgz",
+      "integrity": "sha512-BO98D3TLfKNL80UnE1sIAmI6DQRmOaH0AHnlAooTn1sQjNbRDaeHyRO53EEjo7HjFEdHeQtiRzoXmMB4jvt8AA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.1",
-        "@scalar/json-magic": "0.12.15",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/json-magic": "0.12.17",
         "@scalar/openapi-types": "0.9.1",
         "@scalar/openapi-upgrader": "0.2.9",
         "ajv": "^8.17.1",
@@ -1621,15 +1621,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
-      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.26"
+        "@swc/types": "^0.1.27"
       },
       "engines": {
         "node": ">=10"
@@ -1639,18 +1639,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.40",
-        "@swc/core-darwin-x64": "1.15.40",
-        "@swc/core-linux-arm-gnueabihf": "1.15.40",
-        "@swc/core-linux-arm64-gnu": "1.15.40",
-        "@swc/core-linux-arm64-musl": "1.15.40",
-        "@swc/core-linux-ppc64-gnu": "1.15.40",
-        "@swc/core-linux-s390x-gnu": "1.15.40",
-        "@swc/core-linux-x64-gnu": "1.15.40",
-        "@swc/core-linux-x64-musl": "1.15.40",
-        "@swc/core-win32-arm64-msvc": "1.15.40",
-        "@swc/core-win32-ia32-msvc": "1.15.40",
-        "@swc/core-win32-x64-msvc": "1.15.40"
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
       "cpu": [
         "arm64"
       ],
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
       "cpu": [
         "x64"
       ],
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
       "cpu": [
         "arm"
       ],
@@ -1713,9 +1713,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
       "cpu": [
         "arm64"
       ],
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
       "cpu": [
         "arm64"
       ],
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
       "cpu": [
         "ppc64"
       ],
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
       "cpu": [
         "s390x"
       ],
@@ -1793,9 +1793,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
       "cpu": [
         "x64"
       ],
@@ -1813,9 +1813,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
       "cpu": [
         "x64"
       ],
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
       "cpu": [
         "arm64"
       ],
@@ -1850,9 +1850,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
       "cpu": [
         "ia32"
       ],
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
       "cpu": [
         "x64"
       ],
@@ -1909,9 +1909,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
-      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1926,9 +1926,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2061,9 +2061,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2097,17 +2097,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/type-utils": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2120,7 +2120,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.0",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2136,16 +2136,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2161,14 +2161,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2183,14 +2183,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2201,9 +2201,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2218,15 +2218,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2243,9 +2243,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2257,16 +2257,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.0",
-        "@typescript-eslint/tsconfig-utils": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2285,16 +2285,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2309,13 +2309,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2327,9 +2327,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2677,9 +2677,9 @@
       ]
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2956,9 +2956,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.34",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2994,9 +2994,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -3014,10 +3014,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -3065,9 +3065,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001797",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -3271,12 +3271,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -3385,9 +3385,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.369",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.369.tgz",
-      "integrity": "sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==",
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3454,11 +3454,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5201,9 +5204,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
-      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.7.tgz",
+      "integrity": "sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -5388,9 +5391,9 @@
       "license": "MIT"
     },
     "node_modules/nock": {
-      "version": "14.0.15",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
-      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
+      "version": "14.0.16",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.16.tgz",
+      "integrity": "sha512-8r4KEc6nT1D/fdLD/R1BO1CPaVEL8o40u/guFRJlXabN7vr3RmMqyjsY5Krt0nMwhsOAwXQ/mtN5vy5Jh3aErg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5419,9 +5422,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5840,9 +5843,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+      "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6192,9 +6195,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6227,9 +6230,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6733,16 +6736,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
-      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.0",
-        "@typescript-eslint/parser": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0"
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7061,9 +7064,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.59",
         "@causa/cli": "^1.0.0",
         "@causa/workspace": "^1.0.0",
         "@scalar/json-magic": "^0.12.15",
@@ -44,6 +45,34 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime": {
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.59.tgz",
+      "integrity": "sha512-Rbmy6ooITyiW0lhnJu67HpEEnCO68Bpvkqsc1316CCs2DrpFD9G7xo3PgYVkjpiNhTvpH7v6EpQuog8xbg+Bjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pondwader/socks5-server": "^1.0.10",
+        "commander": "^12.1.0",
+        "node-forge": "^1.4.0",
+        "shell-quote": "^1.8.4",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "srt": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1481,6 +1510,12 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@pondwader/socks5-server": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
+      "integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
+      "license": "MIT"
     },
     "node_modules/@scalar/helpers": {
       "version": "0.8.1",
@@ -5367,6 +5402,15 @@
         "node": ">=18.20.0 <20 || >=20.12.1"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6180,6 +6224,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -7089,6 +7145,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.59",
     "@causa/cli": "^1.0.0",
-    "@causa/workspace": "^1.0.0",
-    "@scalar/json-magic": "^0.12.15",
-    "@scalar/openapi-parser": "^0.28.6",
+    "@causa/workspace": "^1.0.1",
+    "@scalar/json-magic": "^0.12.16",
+    "@scalar/openapi-parser": "^0.28.7",
     "ajv": "^8.20.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
@@ -53,21 +53,21 @@
   },
   "devDependencies": {
     "@scalar/openapi-types": "^0.9.1",
-    "@swc/core": "^1.15.40",
+    "@swc/core": "^1.15.43",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^30.0.0",
     "@types/json-schema": "^7.0.15",
     "@types/micromatch": "^4.0.10",
-    "@types/node": "^22.19.21",
-    "eslint": "^10.4.1",
+    "@types/node": "^22.20.0",
+    "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "jest": "^30.4.2",
     "jest-extended": "^7.0.0",
-    "nock": "^14.0.15",
+    "nock": "^14.0.16",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.0"
+    "typescript-eslint": "^8.62.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "generateConfigurationSchemas": "cs model genCode && perl -pi -e 's|\\@causa/runtime|\\@causa/workspace/validation|g' src/configurations/generated.ts src/scenarios/generated.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.59",
     "@causa/cli": "^1.0.0",
     "@causa/workspace": "^1.0.0",
     "@scalar/json-magic": "^0.12.15",

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -15,44 +15,6 @@ import {
   ValidateNested,
 } from 'class-validator';
 
-/**
- * Additional causa properties used by workspace functions in this package.
- */
-export class Causa {
-  constructor(init: Causa) {
-    Object.assign(this, init);
-  }
-
-  /**
-   * The directory where project configurations are written by the ProjectWriteConfigurations processor.
-   */
-  @AllowMissing()
-  @IsString()
-  readonly projectConfigurationsDirectory?: string;
-
-  [key: string]: any;
-}
-
-/**
- * A configuration with additional `causa` properties used by workspace functions in this package.
- */
-export class CausaConfiguration {
-  constructor(init: CausaConfiguration) {
-    Object.assign(this, init);
-  }
-
-  /**
-   * Additional causa properties used by workspace functions in this package.
-   */
-  @AllowMissing()
-  @IsObject()
-  @Type(() => Causa)
-  @ValidateNested()
-  readonly causa?: Causa;
-
-  [key: string]: any;
-}
-
 export class CodeGenerator {
   constructor(init: CodeGenerator) {
     Object.assign(this, init);
@@ -412,6 +374,254 @@ export class ProjectWriteConfigurationsProcessor {
 export type InfrastructureProcessor =
   | ProcessorInstruction
   | ProjectWriteConfigurationsProcessor;
+
+/**
+ * A masked environment variable, injected by the host into requests to the declared hosts.
+ */
+export class SandboxCredentialEnvironmentVariable {
+  constructor(init: SandboxCredentialEnvironmentVariable) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * The hosts the real value may be injected into. Wildcards such as `*.example.com` are supported.
+   * The credential is never sent to any other host.
+   */
+  @IsArray()
+  @IsString({ each: true })
+  readonly hosts!: string[];
+
+  [key: string]: any;
+}
+
+/**
+ * The credentials the sandboxed process is allowed to use, masked from it and injected by the host.
+ */
+export class SandboxCredentials {
+  constructor(init: SandboxCredentials) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * A map of environment variables to mask, keyed by name. The sandboxed process sees an opaque sentinel
+   * value instead of the real one; the host injects the real value into requests to the declared hosts.
+   * The real value is read from the process spawning the command (its environment or `process.env`), so it
+   * is never stored in the configuration.
+   */
+  @AllowMissing()
+  @IsObject()
+  readonly environment?: Record<string, SandboxCredentialEnvironmentVariable>;
+
+  [key: string]: any;
+}
+
+/**
+ * The filesystem restrictions for the profile. Reads follow a deny-then-allow model (everything readable
+ * unless denied, then re-allowed within denied regions); writes follow an allow-only model. The workspace
+ * root is always readable and writable, and the home directory is always denied for reads, so a profile
+ * that needs to read a toolchain installed under the home directory must re-allow the relevant paths.
+ */
+export class SandboxFilesystem {
+  constructor(init: SandboxFilesystem) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * Additional paths whose reads are denied, on top of the always-denied home directory.
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly denyRead?: string[];
+
+  /**
+   * Paths to re-allow reads for within denied regions, on top of the always-allowed workspace root.
+   * Re-allowed paths take precedence over denied ones.
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly allowRead?: string[];
+
+  /**
+   * Additional paths to allow writes to, on top of the always-allowed workspace root and the runtime's
+   * default write paths (e.g. temporary directories).
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly allowWrite?: string[];
+
+  /**
+   * Paths to deny writes to within allowed regions. Denied paths take precedence over allowed ones.
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly denyWrite?: string[];
+
+  /**
+   * Bypasses all filesystem restrictions when `true`.
+   */
+  @AllowMissing()
+  @IsBoolean()
+  readonly disabled?: boolean;
+
+  [key: string]: any;
+}
+
+/**
+ * The network restrictions for the profile. When omitted, all network access is blocked.
+ */
+export class SandboxNetwork {
+  constructor(init: SandboxNetwork) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * The list of domains the sandboxed process is allowed to reach. This is an allowlist: an empty list (or
+   * an omitted network section) blocks all network access. Wildcards such as `*.example.com` are supported.
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly allowedDomains?: string[];
+
+  /**
+   * The list of domains the sandboxed process is explicitly denied access to. Denied domains take
+   * precedence over allowed ones.
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly deniedDomains?: string[];
+
+  /**
+   * Whether the sandboxed process may bind to or connect to the loopback interface. Defaults to `false`.
+   */
+  @AllowMissing()
+  @IsBoolean()
+  readonly allowLocalBinding?: boolean;
+
+  /**
+   * The list of Unix socket paths the sandboxed process is allowed to use (macOS only).
+   */
+  @AllowMissing()
+  @IsArray()
+  @IsString({ each: true })
+  readonly allowUnixSockets?: string[];
+
+  /**
+   * Whether the sandboxed process is allowed to use any Unix socket.
+   */
+  @AllowMissing()
+  @IsBoolean()
+  readonly allowAllUnixSockets?: boolean;
+
+  [key: string]: any;
+}
+
+/**
+ * A sandbox profile describing how a process is restricted when run inside the OS-level sandbox.
+ */
+export class SandboxProfile {
+  constructor(init: SandboxProfile) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * The network restrictions for the profile. When omitted, all network access is blocked.
+   */
+  @AllowMissing()
+  @IsObject()
+  @Type(() => SandboxNetwork)
+  @ValidateNested()
+  readonly network?: SandboxNetwork;
+
+  /**
+   * The filesystem restrictions for the profile. Reads follow a deny-then-allow model (everything readable
+   * unless denied, then re-allowed within denied regions); writes follow an allow-only model. The workspace
+   * root is always readable and writable, and the home directory is always denied for reads, so a profile
+   * that needs to read a toolchain installed under the home directory must re-allow the relevant paths.
+   */
+  @AllowMissing()
+  @IsObject()
+  @Type(() => SandboxFilesystem)
+  @ValidateNested()
+  readonly filesystem?: SandboxFilesystem;
+
+  /**
+   * The credentials the sandboxed process is allowed to use, masked from it and injected by the host.
+   */
+  @AllowMissing()
+  @IsObject()
+  @Type(() => SandboxCredentials)
+  @ValidateNested()
+  readonly credentials?: SandboxCredentials;
+
+  /**
+   * Weakens the Linux sandbox so it can run nested within an unprivileged container (e.g. in CI). This
+   * reduces the security guarantees and should only be enabled when necessary.
+   */
+  @AllowMissing()
+  @IsBoolean()
+  readonly enableWeakerNestedSandbox?: boolean;
+
+  /**
+   * Weakens network isolation on macOS, required by some statically-linked binaries (e.g. Go) for TLS. This
+   * reduces the security guarantees and should only be enabled when necessary.
+   */
+  @AllowMissing()
+  @IsBoolean()
+  readonly enableWeakerNetworkIsolation?: boolean;
+
+  [key: string]: any;
+}
+
+/**
+ * Additional causa properties used by workspace functions in this package.
+ */
+export class Causa {
+  constructor(init: Causa) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * The directory where project configurations are written by the ProjectWriteConfigurations processor.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly projectConfigurationsDirectory?: string;
+
+  /**
+   * A map of sandbox profiles, keyed by an arbitrary name that can be referenced when running a sandboxed process.
+   */
+  @AllowMissing()
+  @IsObject()
+  readonly sandboxes?: Record<string, SandboxProfile>;
+
+  [key: string]: any;
+}
+
+/**
+ * A configuration with additional `causa` properties used by workspace functions in this package.
+ */
+export class CausaConfiguration {
+  constructor(init: CausaConfiguration) {
+    Object.assign(this, init);
+  }
+
+  /**
+   * Additional causa properties used by workspace functions in this package.
+   */
+  @AllowMissing()
+  @IsObject()
+  @Type(() => Causa)
+  @ValidateNested()
+  readonly causa?: Causa;
+
+  [key: string]: any;
+}
 
 /**
  * Configuration for scenarios.

--- a/src/configurations/index.ts
+++ b/src/configurations/index.ts
@@ -5,6 +5,11 @@ export {
   InfrastructureConfiguration,
   ModelConfiguration,
   OpenApiConfiguration,
+  SandboxCredentialEnvironmentVariable,
+  SandboxCredentials,
+  SandboxFilesystem,
+  SandboxNetwork,
+  SandboxProfile,
   ServerlessFunctionsConfiguration,
   ServiceContainerConfiguration,
 } from './generated.js';

--- a/src/configurations/schemas/causa.yaml
+++ b/src/configurations/schemas/causa.yaml
@@ -12,3 +12,116 @@ properties:
       projectConfigurationsDirectory:
         type: string
         description: The directory where project configurations are written by the ProjectWriteConfigurations processor.
+
+      sandboxes:
+        type: object
+        description: A map of sandbox profiles, keyed by an arbitrary name that can be referenced when running a sandboxed process.
+        additionalProperties:
+          title: SandboxProfile
+          type: object
+          description: A sandbox profile describing how a process is restricted when run inside the OS-level sandbox.
+          properties:
+            network:
+              title: SandboxNetwork
+              type: object
+              description: The network restrictions for the profile. When omitted, all network access is blocked.
+              properties:
+                allowedDomains:
+                  type: array
+                  items:
+                    type: string
+                  description: |-
+                    The list of domains the sandboxed process is allowed to reach. This is an allowlist: an empty list (or
+                    an omitted network section) blocks all network access. Wildcards such as `*.example.com` are supported.
+                deniedDomains:
+                  type: array
+                  items:
+                    type: string
+                  description: |-
+                    The list of domains the sandboxed process is explicitly denied access to. Denied domains take
+                    precedence over allowed ones.
+                allowLocalBinding:
+                  type: boolean
+                  description: |-
+                    Whether the sandboxed process may bind to or connect to the loopback interface. Defaults to `false`.
+                allowUnixSockets:
+                  type: array
+                  items:
+                    type: string
+                  description: The list of Unix socket paths the sandboxed process is allowed to use (macOS only).
+                allowAllUnixSockets:
+                  type: boolean
+                  description: Whether the sandboxed process is allowed to use any Unix socket.
+            filesystem:
+              title: SandboxFilesystem
+              type: object
+              description: |-
+                The filesystem restrictions for the profile. Reads follow a deny-then-allow model (everything readable
+                unless denied, then re-allowed within denied regions); writes follow an allow-only model. The workspace
+                root is always readable and writable, and the home directory is always denied for reads, so a profile
+                that needs to read a toolchain installed under the home directory must re-allow the relevant paths.
+              properties:
+                denyRead:
+                  type: array
+                  items:
+                    type: string
+                  description: Additional paths whose reads are denied, on top of the always-denied home directory.
+                allowRead:
+                  type: array
+                  items:
+                    type: string
+                  description: |-
+                    Paths to re-allow reads for within denied regions, on top of the always-allowed workspace root.
+                    Re-allowed paths take precedence over denied ones.
+                allowWrite:
+                  type: array
+                  items:
+                    type: string
+                  description: |-
+                    Additional paths to allow writes to, on top of the always-allowed workspace root and the runtime's
+                    default write paths (e.g. temporary directories).
+                denyWrite:
+                  type: array
+                  items:
+                    type: string
+                  description: |-
+                    Paths to deny writes to within allowed regions. Denied paths take precedence over allowed ones.
+                disabled:
+                  type: boolean
+                  description: Bypasses all filesystem restrictions when `true`.
+            credentials:
+              title: SandboxCredentials
+              type: object
+              description: The credentials the sandboxed process is allowed to use, masked from it and injected by the host.
+              properties:
+                environment:
+                  type: object
+                  description: |-
+                    A map of environment variables to mask, keyed by name. The sandboxed process sees an opaque sentinel
+                    value instead of the real one; the host injects the real value into requests to the declared hosts.
+                    The real value is read from the process spawning the command (its environment or `process.env`), so it
+                    is never stored in the configuration.
+                  additionalProperties:
+                    title: SandboxCredentialEnvironmentVariable
+                    type: object
+                    description: A masked environment variable, injected by the host into requests to the declared hosts.
+                    properties:
+                      hosts:
+                        type: array
+                        items:
+                          type: string
+                        description: |-
+                          The hosts the real value may be injected into. Wildcards such as `*.example.com` are supported.
+                          The credential is never sent to any other host.
+                    required:
+                      - hosts
+            enableWeakerNestedSandbox:
+              type: boolean
+              description: |-
+                Weakens the Linux sandbox so it can run nested within an unprivileged container (e.g. in CI). This
+                reduces the security guarantees and should only be enabled when necessary.
+            enableWeakerNetworkIsolation:
+              type: boolean
+              description: |-
+                Weakens network isolation on macOS, required by some statically-linked binaries (e.g. Go) for TLS. This
+                reduces the security guarantees and should only be enabled when necessary.

--- a/src/sandbox/coordinator.spec.ts
+++ b/src/sandbox/coordinator.spec.ts
@@ -1,0 +1,295 @@
+import {
+  SandboxManager,
+  type SandboxRuntimeConfig,
+} from '@anthropic-ai/sandbox-runtime';
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import { SandboxCoordinator, SandboxNotSupportedError } from './coordinator.js';
+
+describe('SandboxCoordinator', () => {
+  const configA: SandboxRuntimeConfig = {
+    network: { allowedDomains: ['a.example.com'], deniedDomains: [] },
+    filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
+  };
+  const configB: SandboxRuntimeConfig = {
+    network: { allowedDomains: ['b.example.com'], deniedDomains: [] },
+    filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
+  };
+  const configCredentials: SandboxRuntimeConfig = {
+    network: {
+      allowedDomains: ['api.example.com'],
+      deniedDomains: [],
+      tlsTerminate: {},
+    },
+    filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
+    credentials: {
+      envVars: [
+        { name: 'TOKEN', mode: 'mask', injectHosts: ['api.example.com'] },
+      ],
+    },
+  };
+
+  let coordinator: SandboxCoordinator;
+
+  beforeEach(() => {
+    jest.spyOn(SandboxManager, 'isSupportedPlatform').mockReturnValue(true);
+    jest
+      .spyOn(SandboxManager, 'checkDependencies')
+      .mockReturnValue({ errors: [], warnings: [] });
+    jest.spyOn(SandboxManager, 'initialize').mockResolvedValue(undefined);
+    jest.spyOn(SandboxManager, 'updateConfig').mockReturnValue(undefined);
+    jest.spyOn(SandboxManager, 'reset').mockResolvedValue(undefined);
+    jest
+      .spyOn(SandboxManager, 'cleanupAfterCommand')
+      .mockReturnValue(undefined);
+    jest
+      .spyOn(SandboxManager, 'wrapWithSandboxArgv')
+      .mockResolvedValue({ argv: ['/bin/bash', '-c', ':'], env: {} });
+
+    coordinator = new SandboxCoordinator();
+  });
+
+  afterEach(() => SandboxManager.getSentinelRegistry().clear());
+
+  it('should lazily initialize the manager on the first acquisition', async () => {
+    expect(SandboxManager.initialize).not.toHaveBeenCalled();
+
+    await coordinator.acquire(configA, 'node', [], undefined);
+
+    expect(SandboxManager.initialize).toHaveBeenCalledExactlyOnceWith(configA);
+  });
+
+  it('should run sandboxed commands one at a time', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+
+    let secondAcquired = false;
+    const second = coordinator
+      .acquire(configA, 'node', [], undefined)
+      .then(() => {
+        secondAcquired = true;
+      });
+
+    expect(secondAcquired).toBeFalse();
+
+    release();
+    await second;
+
+    expect(secondAcquired).toBeTrue();
+  });
+
+  it('should wrap the quoted command and return the spawn-ready argv and merged environment', async () => {
+    const { argv, environment, release } = await coordinator.acquire(
+      configA,
+      'npm',
+      ['ci', "a'b"],
+      { CALLER: 'x' },
+    );
+
+    expect(SandboxManager.wrapWithSandboxArgv).toHaveBeenCalledExactlyOnceWith(
+      "'npm' 'ci' 'a'\\''b'",
+      undefined,
+      { ...configA, credentials: {} },
+    );
+    expect(argv).toEqual(['/bin/bash', '-c', ':']);
+    expect(environment).toEqual({ CALLER: 'x' });
+    expect(release).toBeFunction();
+  });
+
+  it('should clean up the per-command artifacts on release', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+    release();
+
+    expect(SandboxManager.cleanupAfterCommand).toHaveBeenCalledOnce();
+  });
+
+  it('should reuse the configuration when the next command requests an identical one', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+    release();
+
+    await coordinator.acquire(
+      JSON.parse(JSON.stringify(configA)),
+      'node',
+      [],
+      undefined,
+    );
+
+    expect(SandboxManager.initialize).toHaveBeenCalledOnce();
+    expect(SandboxManager.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('should re-apply the configuration when the next command requests a different one', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+    release();
+
+    await coordinator.acquire(configB, 'node', [], undefined);
+
+    expect(SandboxManager.initialize).toHaveBeenCalledOnce();
+    expect(SandboxManager.updateConfig).toHaveBeenCalledExactlyOnceWith(
+      configB,
+    );
+  });
+
+  it('should reinitialize the manager when an initialization-fixed field changes', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+    release();
+
+    await coordinator.acquire(configCredentials, 'node', [], undefined);
+
+    expect(SandboxManager.reset).toHaveBeenCalledOnce();
+    expect(SandboxManager.initialize).toHaveBeenCalledTimes(2);
+    expect(SandboxManager.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('should mask declared credentials from the caller environment and strip them from the wrap config', async () => {
+    const registry = SandboxManager.getSentinelRegistry();
+
+    const { environment } = await coordinator.acquire(
+      configCredentials,
+      'node',
+      [],
+      { TOKEN: 'real-secret', OTHER: 'keep' },
+    );
+
+    expect(environment).toMatchObject({
+      TOKEN: expect.toStartWith('fake_value_'),
+      OTHER: 'keep',
+    });
+    expect(registry.lookupReal(environment.TOKEN!)).toEqual('real-secret');
+
+    // The wrap configuration has credentials neutralized so the runtime does not also mask them.
+    expect(SandboxManager.wrapWithSandboxArgv).toHaveBeenCalledExactlyOnceWith(
+      expect.any(String),
+      undefined,
+      expect.objectContaining({ credentials: {} }),
+    );
+  });
+
+  it('should deny (unset) a credential declared with deny mode', async () => {
+    const denyConfig: SandboxRuntimeConfig = {
+      network: { allowedDomains: [], deniedDomains: [] },
+      filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
+      credentials: { envVars: [{ name: 'SECRET', mode: 'deny' }] },
+    };
+
+    const { environment } = await coordinator.acquire(denyConfig, 'node', [], {
+      SECRET: 'real-secret',
+      OTHER: 'keep',
+    });
+
+    expect(environment).not.toContainKey('SECRET');
+    expect(environment.OTHER).toEqual('keep');
+  });
+
+  it('should clear masked credentials on release', async () => {
+    const registry = SandboxManager.getSentinelRegistry();
+
+    const { release } = await coordinator.acquire(
+      configCredentials,
+      'node',
+      [],
+      { TOKEN: 'real-secret' },
+    );
+    expect(registry.size).toBeGreaterThan(0);
+
+    release();
+
+    expect(registry.size).toEqual(0);
+  });
+
+  it('should reject when the platform is not supported', async () => {
+    jest.spyOn(SandboxManager, 'isSupportedPlatform').mockReturnValue(false);
+
+    const actualPromise = coordinator.acquire(configA, 'node', [], undefined);
+
+    await expect(actualPromise).rejects.toThrow(SandboxNotSupportedError);
+    expect(SandboxManager.initialize).not.toHaveBeenCalled();
+  });
+
+  it('should reject when sandbox dependencies are missing', async () => {
+    jest
+      .spyOn(SandboxManager, 'checkDependencies')
+      .mockReturnValue({ errors: ['ripgrep (rg) not found'], warnings: [] });
+
+    const actualPromise = coordinator.acquire(configA, 'node', [], undefined);
+
+    await expect(actualPromise).rejects.toThrow(SandboxNotSupportedError);
+    expect(SandboxManager.initialize).not.toHaveBeenCalled();
+  });
+
+  it('should release the hold so the next command can run when applying the configuration fails', async () => {
+    jest
+      .spyOn(SandboxManager, 'initialize')
+      .mockRejectedValueOnce(new Error('💥'));
+
+    await expect(
+      coordinator.acquire(configA, 'node', [], undefined),
+    ).rejects.toThrow('💥');
+
+    await coordinator.acquire(configA, 'node', [], undefined);
+    expect(SandboxManager.initialize).toHaveBeenCalledTimes(2);
+  });
+
+  it('should wait for the running command to release before resetting', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+
+    let didReset = false;
+    const resetPromise = coordinator.reset().then(() => {
+      didReset = true;
+    });
+
+    expect(didReset).toBeFalse();
+    expect(SandboxManager.reset).not.toHaveBeenCalled();
+
+    release();
+    await resetPromise;
+
+    expect(didReset).toBeTrue();
+    expect(SandboxManager.reset).toHaveBeenCalledOnce();
+  });
+
+  it('should tear down the manager and allow re-initialization on reset', async () => {
+    const { release } = await coordinator.acquire(
+      configA,
+      'node',
+      [],
+      undefined,
+    );
+    release();
+    await coordinator.reset();
+
+    expect(SandboxManager.reset).toHaveBeenCalledOnce();
+
+    await coordinator.acquire(configA, 'node', [], undefined);
+    expect(SandboxManager.initialize).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/sandbox/coordinator.ts
+++ b/src/sandbox/coordinator.ts
@@ -1,0 +1,274 @@
+import {
+  SandboxManager,
+  type SandboxRuntimeConfig,
+} from '@anthropic-ai/sandbox-runtime';
+import { isDeepStrictEqual } from 'util';
+import { mergeSandboxEnvironment } from './environment.js';
+
+/**
+ * An error thrown when sandboxing is requested but the current environment cannot support it (unsupported platform, or
+ * missing OS dependencies).
+ */
+export class SandboxNotSupportedError extends Error {}
+
+/**
+ * A sandboxed command prepared by {@link SandboxCoordinator.acquire}, ready to be spawned.
+ */
+export type AcquiredSandboxCommand = {
+  /**
+   * The sandbox-wrapped argv to spawn.
+   */
+  readonly argv: string[];
+
+  /**
+   * The environment to spawn the command with: the caller's environment merged with the one the sandbox requires.
+   */
+  readonly environment: Record<string, string | undefined>;
+
+  /**
+   * Cleans up the command's per-command artifacts and releases the serialization lock so the next command can run.
+   * Must be called once the command has finished (or failed to start). Idempotent.
+   */
+  readonly release: () => void;
+};
+
+/**
+ * Coordinates access to the process-wide `SandboxManager` singleton.
+ *
+ * The sandbox runtime exposes a single manager per process.
+ * Sandboxed commands are therefore run strictly one at a time. As the only optimization, the global configuration is
+ * reused as-is (not re-applied) when a command requests the exact same one as the previous command.
+ *
+ * Teardown is handled by the sandbox runtime itself: `SandboxManager.initialize()` registers `exit`/`SIGINT`/`SIGTERM`
+ * handlers that call its own `reset()`.
+ */
+export class SandboxCoordinator {
+  /**
+   * The configuration currently applied to the manager, or `undefined` if none has been applied yet.
+   */
+  private activeConfig: SandboxRuntimeConfig | undefined;
+
+  /**
+   * Whether `SandboxManager.initialize()` has been called (and the proxies started) in this process.
+   */
+  private initialized = false;
+
+  /**
+   * Whether the platform/dependency support check has already passed.
+   */
+  private supportChecked = false;
+
+  /**
+   * The tail of the serialization chain: a promise that resolves once the currently-running command releases.
+   * The next {@link SandboxCoordinator.acquire} awaits it before running, ensuring commands run one at a time.
+   */
+  private tail: Promise<void> = Promise.resolve();
+
+  /**
+   * Acquires the exclusive right to run a sandboxed command and prepares it: waits for the previous command to release,
+   * applies the configuration, and wraps the command for execution inside the sandbox. The returned argv and
+   * environment are ready to be spawned.
+   *
+   * Each successful call returns a `release` function that must be called once the command has finished (or failed to
+   * start) to clean up its per-command artifacts and let the next command run.
+   *
+   * @param config The configuration the command requires.
+   * @param command The command to run.
+   * @param args The arguments to pass to the command.
+   * @param environment The caller's environment, merged with the one the sandbox requires.
+   * @returns The sandbox-wrapped argv, the environment to spawn it with, and the `release` function.
+   */
+  async acquire(
+    config: SandboxRuntimeConfig,
+    command: string,
+    args: string[],
+    environment: Record<string, string | undefined> | undefined,
+  ): Promise<AcquiredSandboxCommand> {
+    this.ensureSupported();
+
+    const releaseLock = await this.lock();
+
+    try {
+      await this.applyConfig(config);
+
+      const commandString = [command, ...args]
+        .map((token) => `'${token.replaceAll("'", `'\\''`)}'`)
+        .join(' ');
+      const { argv, env: sbxEnv } = await SandboxManager.wrapWithSandboxArgv(
+        commandString,
+        undefined,
+        // Credentials are masked by the coordinator, so they are stripped from the configuration.
+        { ...config, credentials: {} },
+      );
+
+      const env = mergeSandboxEnvironment(environment, sbxEnv);
+      this.applyCredentials(config, environment, env);
+
+      const release = this.makeRelease(releaseLock);
+      return { argv, environment: env, release };
+    } catch (error) {
+      releaseLock();
+      throw error;
+    }
+  }
+
+  /**
+   * Applies the profile's declared credential environment variables to the child's environment in place:
+   *
+   * - `mask`: the real value is read from the spawning process (the caller's `environment`, falling back to
+   *   `process.env`), registered under a per-session sentinel, and substituted for the sentinel in the child's
+   *   environment. The runtime's own masking reads `process.env` only, so it cannot see values passed through
+   *   `environment`. The coordinator masks them here instead.
+   * - `deny`: the variable is removed from the child's environment.
+   *
+   * @param config The configuration whose credentials declare the variables to apply.
+   * @param callerEnvironment The caller's environment, the primary source of the real values.
+   * @param environment The environment to spawn the command with, mutated in place.
+   */
+  private applyCredentials(
+    config: SandboxRuntimeConfig,
+    callerEnvironment: Record<string, string | undefined> | undefined,
+    environment: Record<string, string | undefined>,
+  ): void {
+    const registry = SandboxManager.getSentinelRegistry();
+    for (const { name, mode, injectHosts } of config.credentials?.envVars ??
+      []) {
+      if (mode === 'deny') {
+        delete environment[name];
+        continue;
+      }
+
+      const real = callerEnvironment?.[name] ?? process.env[name];
+      if (real !== undefined) {
+        environment[name] = registry.register(name, real, injectHosts ?? []);
+      }
+    }
+  }
+
+  /**
+   * Builds the `release` function returned by {@link SandboxCoordinator.acquire}. It cleans up the per-command sandbox
+   * artifacts (e.g. Linux bwrap mount points) and frees the serialization lock. It is idempotent.
+   *
+   * @param releaseLock The function freeing the serialization lock.
+   * @returns The `release` function.
+   */
+  private makeRelease(releaseLock: () => void): () => void {
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+
+      SandboxManager.cleanupAfterCommand();
+      SandboxManager.getSentinelRegistry().clear();
+      releaseLock();
+    };
+  }
+
+  /**
+   * Takes the serialization lock, resolving once the previous holder (a command or a {@link SandboxCoordinator.reset})
+   * has released. The returned function must be called to release the lock and let the next holder proceed.
+   *
+   * @returns The function releasing the lock.
+   */
+  private async lock(): Promise<() => void> {
+    const previous = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => (release = resolve));
+    await previous;
+    return release;
+  }
+
+  /**
+   * Applies a configuration to the manager.
+   *
+   * - Identical to the active one: reused as-is.
+   * - Differing only in the live-updatable network allow/deny lists: applied with `updateConfig`.
+   * - Differing in an initialization-fixed field (e.g. TLS termination): the manager is torn down and re-initialized.
+   *
+   * @param config The configuration to apply.
+   */
+  private async applyConfig(config: SandboxRuntimeConfig): Promise<void> {
+    const active = this.activeConfig;
+    if (this.initialized && active) {
+      if (isDeepStrictEqual(config, active)) {
+        return;
+      }
+
+      // Only the network allow/deny lists are live-updatable. `tlsTerminate` (the mitm CA) and the presence of
+      // `credentials` (which wires the credential injector) are fixed at initialization, so a change in either requires
+      // tearing the manager down.
+      const requiresReinitialization =
+        (config.credentials === undefined) !==
+          (active.credentials === undefined) ||
+        !isDeepStrictEqual(
+          config.network.tlsTerminate,
+          active.network.tlsTerminate,
+        );
+
+      if (!requiresReinitialization) {
+        SandboxManager.updateConfig(config);
+        this.activeConfig = config;
+        return;
+      }
+
+      await SandboxManager.reset();
+      this.initialized = false;
+    }
+
+    await SandboxManager.initialize(config);
+    this.initialized = true;
+    this.activeConfig = config;
+  }
+
+  /**
+   * Checks (once) that the current platform supports sandboxing and that the required OS dependencies are present.
+   *
+   * @throws {SandboxNotSupportedError} If the platform is unsupported or dependencies are missing.
+   */
+  private ensureSupported(): void {
+    if (this.supportChecked) {
+      return;
+    }
+
+    if (!SandboxManager.isSupportedPlatform()) {
+      throw new SandboxNotSupportedError(
+        'Sandboxing is not supported on this platform.',
+      );
+    }
+
+    const { errors } = SandboxManager.checkDependencies();
+    if (errors.length > 0) {
+      throw new SandboxNotSupportedError(
+        `Sandboxing dependencies are missing: ${errors.join(', ')}.`,
+      );
+    }
+
+    this.supportChecked = true;
+  }
+
+  /**
+   * Tears down the manager and resets the coordinator's state.
+   * Mostly useful for tests and explicit shutdowns. In normal CLI usage the sandbox runtime resets itself on process
+   * exit.
+   */
+  async reset(): Promise<void> {
+    const release = await this.lock();
+
+    try {
+      this.activeConfig = undefined;
+      this.initialized = false;
+      this.supportChecked = false;
+
+      await SandboxManager.reset();
+    } finally {
+      release();
+    }
+  }
+}
+
+/**
+ * The process-global {@link SandboxCoordinator} shared by all {@link ProcessService} instances (across contexts).
+ */
+export const sandboxCoordinator = new SandboxCoordinator();

--- a/src/sandbox/environment.ts
+++ b/src/sandbox/environment.ts
@@ -1,0 +1,27 @@
+/**
+ * Combines the caller's environment with the changes the sandbox runtime needs to apply to the spawned process.
+ *
+ * The sandbox returns a full environment, most of which is identical to the current process's environment. Spreading it
+ * wholesale over the caller's environment would overwrite the variables the caller explicitly set. Instead, only the
+ * variables the sandbox actually added or changed (compared to the current process's environment) are layered on top of
+ * the caller's environment. This preserves the caller's customizations while still applying what the sandbox requires.
+ *
+ * @param callerEnvironment The environment requested by the caller, if any. Defaults to {@link process.env}.
+ * @param sandboxEnvironment The environment returned by the sandbox runtime when wrapping the command.
+ * @returns The environment to pass to the spawned process.
+ */
+export function mergeSandboxEnvironment(
+  callerEnvironment: Record<string, string | undefined> | undefined,
+  sandboxEnvironment: NodeJS.ProcessEnv,
+): Record<string, string | undefined> {
+  const base = callerEnvironment ?? process.env;
+
+  const delta: Record<string, string | undefined> = {};
+  for (const [name, value] of Object.entries(sandboxEnvironment)) {
+    if (process.env[name] !== value) {
+      delta[name] = value;
+    }
+  }
+
+  return { ...base, ...delta };
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,0 +1,11 @@
+export {
+  SandboxCoordinator,
+  sandboxCoordinator,
+  SandboxNotSupportedError,
+  type AcquiredSandboxCommand,
+} from './coordinator.js';
+export {
+  InvalidSandboxProfileError,
+  resolveSandboxProfile,
+  SandboxProfileNotFoundError,
+} from './profile.js';

--- a/src/sandbox/profile.spec.ts
+++ b/src/sandbox/profile.spec.ts
@@ -1,0 +1,170 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import type { SandboxProfile } from '../configurations/index.js';
+import {
+  InvalidSandboxProfileError,
+  SandboxProfileNotFoundError,
+  resolveSandboxProfile,
+} from './profile.js';
+
+describe('resolveSandboxProfile', () => {
+  const rootPath = '/workspace/root';
+
+  function makeContext(
+    sandboxes?: Record<string, SandboxProfile>,
+  ): WorkspaceContext {
+    const { context } = createContext({
+      rootPath,
+      workingDirectory: rootPath,
+      configuration: sandboxes ? { causa: { sandboxes } } : {},
+    });
+    return context;
+  }
+
+  it('should throw when the referenced profile is not configured', () => {
+    const noSandboxesContext = makeContext();
+    expect(() => resolveSandboxProfile(noSandboxesContext, 'install')).toThrow(
+      SandboxProfileNotFoundError,
+    );
+
+    const missingSandboxContext = makeContext({
+      install: { network: { allowedDomains: [] } },
+    });
+    expect(() =>
+      resolveSandboxProfile(missingSandboxContext, 'missing'),
+    ).toThrow(SandboxProfileNotFoundError);
+  });
+
+  it('should resolve a full profile, merging the auto-injected paths into the filesystem restrictions', () => {
+    const context = makeContext({
+      install: {
+        network: {
+          allowedDomains: ['registry.npmjs.org', '*.npmjs.org'],
+          deniedDomains: ['evil.example.com'],
+          allowLocalBinding: true,
+          allowUnixSockets: ['/var/run/docker.sock'],
+          allowAllUnixSockets: false,
+        },
+        filesystem: {
+          denyRead: ['/secrets'],
+          allowRead: ['~/.npm', '~/.asdf'],
+          allowWrite: ['~/.npm'],
+          denyWrite: ['/workspace/root/.env'],
+          disabled: false,
+        },
+        enableWeakerNestedSandbox: true,
+        enableWeakerNetworkIsolation: true,
+      },
+    });
+
+    const resolved = resolveSandboxProfile(context, 'install');
+
+    expect(resolved).toEqual({
+      network: {
+        allowedDomains: ['registry.npmjs.org', '*.npmjs.org'],
+        deniedDomains: ['evil.example.com'],
+        allowLocalBinding: true,
+        allowUnixSockets: ['/var/run/docker.sock'],
+        allowAllUnixSockets: false,
+      },
+      filesystem: {
+        denyRead: ['~', '/secrets'],
+        allowRead: [rootPath, '~/.npm', '~/.asdf'],
+        allowWrite: [rootPath, '~/.npm'],
+        denyWrite: ['/workspace/root/.env'],
+        disabled: false,
+      },
+      enableWeakerNestedSandbox: true,
+      enableWeakerNetworkIsolation: true,
+    });
+  });
+
+  it('should apply defaults, blocking all network access and restricting the filesystem to the workspace root', () => {
+    const context = makeContext({ build: {} });
+
+    const resolved = resolveSandboxProfile(context, 'build');
+
+    expect(resolved).toEqual({
+      network: {
+        allowedDomains: [],
+        deniedDomains: [],
+      },
+      filesystem: {
+        denyRead: ['~'],
+        allowRead: [rootPath],
+        allowWrite: [rootPath],
+        denyWrite: [],
+      },
+    });
+  });
+
+  it('should map masked credentials and enable TLS termination', () => {
+    const context = makeContext({
+      install: {
+        network: { allowedDomains: ['registry.npmjs.org'] },
+        credentials: {
+          environment: {
+            NPM_TOKEN: { hosts: ['registry.npmjs.org'] },
+          },
+        },
+      },
+    });
+
+    const resolved = resolveSandboxProfile(context, 'install');
+
+    expect(resolved.network.tlsTerminate).toEqual({});
+    expect(resolved.credentials).toEqual({
+      envVars: [
+        {
+          name: 'NPM_TOKEN',
+          mode: 'mask',
+          injectHosts: ['registry.npmjs.org'],
+        },
+      ],
+    });
+  });
+
+  it('should deny a credential with no hosts rather than mask it, without enabling TLS termination', () => {
+    const context = makeContext({
+      install: {
+        network: { allowedDomains: ['registry.npmjs.org'] },
+        credentials: {
+          environment: {
+            AWS_SECRET_ACCESS_KEY: { hosts: [] },
+          },
+        },
+      },
+    });
+
+    const resolved = resolveSandboxProfile(context, 'install');
+
+    expect(resolved.network.tlsTerminate).toBeUndefined();
+    expect(resolved.credentials).toEqual({
+      envVars: [{ name: 'AWS_SECRET_ACCESS_KEY', mode: 'deny' }],
+    });
+  });
+
+  it('should not enable TLS termination when no credentials are declared', () => {
+    const context = makeContext({ build: { network: { allowedDomains: [] } } });
+
+    const resolved = resolveSandboxProfile(context, 'build');
+
+    expect(resolved.network.tlsTerminate).toBeUndefined();
+    expect(resolved.credentials).toBeUndefined();
+  });
+
+  it('should throw, surfacing the offending path, when the profile is invalid', () => {
+    const context = makeContext({
+      bad: { network: { allowedDomains: ['not a domain'] } },
+    });
+
+    try {
+      resolveSandboxProfile(context, 'bad');
+      throw new Error('Expected the resolution to throw.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidSandboxProfileError);
+      expect((error as InvalidSandboxProfileError).key).toEqual('bad');
+      expect((error as Error).message).toContain('allowedDomains');
+    }
+  });
+});

--- a/src/sandbox/profile.ts
+++ b/src/sandbox/profile.ts
@@ -1,0 +1,95 @@
+import {
+  SandboxRuntimeConfigSchema,
+  type SandboxRuntimeConfig,
+} from '@anthropic-ai/sandbox-runtime';
+import { WorkspaceContext } from '@causa/workspace';
+import type { CausaConfiguration } from '../configurations/index.js';
+
+/**
+ * An error thrown when a referenced sandbox profile is not configured.
+ */
+export class SandboxProfileNotFoundError extends Error {
+  constructor(readonly key: string) {
+    super(
+      `No sandbox profile is configured for key '${key}' under 'causa.sandboxes'.`,
+    );
+  }
+}
+
+/**
+ * An error thrown when a sandbox profile fails validation against the sandbox runtime's schema.
+ */
+export class InvalidSandboxProfileError extends Error {
+  constructor(
+    readonly key: string,
+    cause: unknown,
+  ) {
+    super(
+      `Invalid sandbox profile '${key}': ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Resolves a sandbox profile referenced by key against the given context, into a full sandbox runtime configuration.
+ *
+ * @param context The {@link WorkspaceContext} from which the configuration and workspace root are read.
+ * @param key The key of the profile to resolve.
+ * @returns The resolved {@link SandboxRuntimeConfig}.
+ * @throws {SandboxProfileNotFoundError} If no profile is configured for the given key.
+ * @throws {InvalidSandboxProfileError} If the profile fails validation against the sandbox runtime's schema.
+ */
+export function resolveSandboxProfile(
+  context: WorkspaceContext,
+  key: string,
+): SandboxRuntimeConfig {
+  const profile = context
+    .asConfiguration<CausaConfiguration>()
+    .get(`causa.sandboxes.${key}`);
+  if (!profile) {
+    throw new SandboxProfileNotFoundError(key);
+  }
+
+  const rootPath = context.rootPath;
+
+  const envVars = Object.entries(profile.credentials?.environment ?? {}).map(
+    ([name, { hosts: injectHosts }]) =>
+      injectHosts.length > 0
+        ? ({ name, mode: 'mask', injectHosts } as const)
+        : ({ name, mode: 'deny' } as const),
+  );
+  const hasMaskedCredentials = envVars.some((v) => v.mode === 'mask');
+
+  // The workspace root is auto-injected so the spawned process can read and write the project it operates on, and the
+  // home directory (`~`) is denied for reads to keep unrelated secrets (SSH keys, other projects, credentials) out of
+  // reach.
+  const candidate: SandboxRuntimeConfig = {
+    network: {
+      allowedDomains: profile.network?.allowedDomains ?? [],
+      deniedDomains: profile.network?.deniedDomains ?? [],
+      allowLocalBinding: profile.network?.allowLocalBinding,
+      allowUnixSockets: profile.network?.allowUnixSockets,
+      allowAllUnixSockets: profile.network?.allowAllUnixSockets,
+      // Credential masking requires TLS termination so the real value is only substituted over a verified connection.
+      // It is enabled automatically (with an ephemeral CA) when the profile declares masked credentials.
+      ...(hasMaskedCredentials ? { tlsTerminate: {} } : {}),
+    },
+    filesystem: {
+      denyRead: ['~', ...(profile.filesystem?.denyRead ?? [])],
+      allowRead: [rootPath, ...(profile.filesystem?.allowRead ?? [])],
+      allowWrite: [rootPath, ...(profile.filesystem?.allowWrite ?? [])],
+      denyWrite: [...(profile.filesystem?.denyWrite ?? [])],
+      disabled: profile.filesystem?.disabled,
+    },
+    ...(envVars.length > 0 ? { credentials: { envVars } } : {}),
+    enableWeakerNestedSandbox: profile.enableWeakerNestedSandbox,
+    enableWeakerNetworkIsolation: profile.enableWeakerNetworkIsolation,
+  };
+
+  try {
+    return SandboxRuntimeConfigSchema.parse(candidate);
+  } catch (error) {
+    throw new InvalidSandboxProfileError(key, error);
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,5 +6,9 @@ export { DockerService } from './docker.js';
 export type { DockerContainerMount, DockerContainerPublish } from './docker.js';
 export { GitService } from './git.js';
 export { ProcessService, ProcessServiceExitCodeError } from './process.js';
-export type { SpawnOptions, SpawnedProcessResult } from './process.js';
+export type {
+  SandboxedSpawnOptions,
+  SpawnOptions,
+  SpawnedProcessResult,
+} from './process.js';
 export { ServiceContainerBuilderService } from './service-container-builder.js';

--- a/src/services/process.spec.ts
+++ b/src/services/process.spec.ts
@@ -1,3 +1,4 @@
+import { SandboxManager } from '@anthropic-ai/sandbox-runtime';
 import { WorkspaceContext } from '@causa/workspace';
 import { createContext } from '@causa/workspace/testing';
 import { jest } from '@jest/globals';
@@ -5,6 +6,8 @@ import 'jest-extended';
 import { dirname } from 'path';
 import type { Logger } from 'pino';
 import { fileURLToPath } from 'url';
+import { sandboxCoordinator } from '../sandbox/coordinator.js';
+import { SandboxProfileNotFoundError } from '../sandbox/profile.js';
 import { ProcessService, ProcessServiceExitCodeError } from './process.js';
 
 describe('ProcessService', () => {
@@ -115,6 +118,110 @@ describe('ProcessService', () => {
       const actualPromise = actualProcess.result;
       await expect(actualPromise).rejects.toThrow(ProcessServiceExitCodeError);
       await expect(actualPromise).rejects.toMatchObject({
+        command: 'node',
+        args: ['-e', 'process.exit(5)'],
+        result: { code: 5 },
+      });
+    });
+  });
+
+  describe('spawnSandboxed', () => {
+    const dir = dirname(fileURLToPath(import.meta.url));
+
+    beforeEach(() => {
+      jest.spyOn(SandboxManager, 'isSupportedPlatform').mockReturnValue(true);
+      jest
+        .spyOn(SandboxManager, 'checkDependencies')
+        .mockReturnValue({ errors: [], warnings: [] });
+      jest.spyOn(SandboxManager, 'initialize').mockResolvedValue(undefined);
+      jest.spyOn(SandboxManager, 'updateConfig').mockReturnValue(undefined);
+      jest.spyOn(SandboxManager, 'reset').mockResolvedValue(undefined);
+      jest
+        .spyOn(SandboxManager, 'cleanupAfterCommand')
+        .mockReturnValue(undefined);
+    });
+
+    afterEach(() => sandboxCoordinator.reset());
+
+    function mockPassthroughWrapping() {
+      jest
+        .spyOn(SandboxManager, 'wrapWithSandboxArgv')
+        .mockImplementation(async (command) => ({
+          argv: ['/bin/bash', '-c', command],
+          env: process.env,
+        }));
+    }
+
+    function createSandboxedService(): ProcessService {
+      ({ context } = createContext({
+        workingDirectory: dir,
+        rootPath: dir,
+        configuration: {
+          causa: { sandboxes: { test: { network: { allowedDomains: [] } } } },
+        },
+      }));
+      return context.service(ProcessService);
+    }
+
+    it('should wrap the command when a configured sandbox key is used', async () => {
+      mockPassthroughWrapping();
+      service = createSandboxedService();
+
+      const actualProcess = await service.spawn(
+        'node',
+        ['-e', 'console.log("🎉")'],
+        { capture: { stdout: true }, sandbox: 'test' },
+      );
+      const actualResult = await actualProcess.result;
+
+      expect(actualResult.code).toEqual(0);
+      expect(actualResult.stdout).toEqual('🎉\n');
+      expect(SandboxManager.initialize).toHaveBeenCalledOnce();
+      expect(
+        SandboxManager.wrapWithSandboxArgv,
+      ).toHaveBeenCalledExactlyOnceWith(
+        "'node' '-e' 'console.log(\"🎉\")'",
+        undefined,
+        {
+          network: { allowedDomains: [], deniedDomains: [] },
+          filesystem: {
+            denyRead: ['~'],
+            allowRead: [dir],
+            allowWrite: [dir],
+            denyWrite: [],
+          },
+          credentials: {},
+        },
+      );
+      expect(SandboxManager.cleanupAfterCommand).toHaveBeenCalledOnce();
+    });
+
+    it('should reject rather than run unsandboxed when the sandbox key is not configured', async () => {
+      jest.spyOn(SandboxManager, 'wrapWithSandboxArgv');
+      service = createSandboxedService();
+
+      const actualPromise = service.spawn(
+        'node',
+        ['-e', 'console.log("plain")'],
+        { capture: { stdout: true }, sandbox: 'missing' },
+      );
+
+      await expect(actualPromise).rejects.toThrow(SandboxProfileNotFoundError);
+      expect(SandboxManager.wrapWithSandboxArgv).not.toHaveBeenCalled();
+      expect(SandboxManager.initialize).not.toHaveBeenCalled();
+    });
+
+    it('should report exit code failures against the original command', async () => {
+      mockPassthroughWrapping();
+      service = createSandboxedService();
+
+      const actualProcess = await service.spawn(
+        'node',
+        ['-e', 'process.exit(5)'],
+        { sandbox: 'test' },
+      );
+
+      await expect(actualProcess.result).rejects.toMatchObject({
         command: 'node',
         args: ['-e', 'process.exit(5)'],
         result: { code: 5 },

--- a/src/services/process.ts
+++ b/src/services/process.ts
@@ -2,6 +2,7 @@ import { WorkspaceContext } from '@causa/workspace';
 import { ChildProcess, spawn } from 'child_process';
 import type { Level, Logger } from 'pino';
 import { Readable } from 'stream';
+import { resolveSandboxProfile, sandboxCoordinator } from '../sandbox/index.js';
 
 /**
  * Options specifying how outputs of a spawned process should be forwarded to the logger.
@@ -63,6 +64,17 @@ export type SpawnOptions = {
    * By default, nothing is captured.
    */
   capture?: SpawnCaptureOption;
+};
+
+/**
+ * {@link SpawnOptions} extended with the optional sandbox profile key.
+ */
+export type SandboxedSpawnOptions = SpawnOptions & {
+  /**
+   * The key of the sandbox profile, defined under the `causa.sandboxes` configuration, in which the process should run.
+   * When set, {@link ProcessService.spawn} runs the process inside the sandbox and returns a promise.
+   */
+  sandbox?: string;
 };
 
 /**
@@ -135,11 +147,31 @@ export class ProcessService {
    */
   private readonly defaultWorkingDirectory: string;
 
+  /**
+   * The {@link WorkspaceContext}.
+   */
+  private readonly context: WorkspaceContext;
+
   constructor(context: WorkspaceContext) {
     this.logger = context.logger;
     this.defaultWorkingDirectory = context.workingDirectory;
+    this.context = context;
   }
 
+  /**
+   * Spawns a new child process inside the OS-level sandbox referenced by the `sandbox` option.
+   * The sandbox requires asynchronous preparation, so a promise resolving to the {@link SpawnedProcess} is returned.
+   *
+   * @param command The command to run.
+   * @param args The arguments to pass to the command.
+   * @param options Options when running the command, including the sandbox profile key.
+   * @returns A promise resolving to a {@link SpawnedProcess} once the sandbox is prepared and the process has started.
+   */
+  spawn(
+    command: string,
+    args: string[],
+    options: SandboxedSpawnOptions & { sandbox: string },
+  ): Promise<SpawnedProcess>;
   /**
    * Spawns a new child process using {@link spawn}.
    *
@@ -149,6 +181,85 @@ export class ProcessService {
    * @returns A {@link SpawnedProcess}. {@link SpawnedProcess.result} can be awaited until the process exits.
    */
   spawn(
+    command: string,
+    args: string[],
+    options?: SpawnOptions,
+  ): SpawnedProcess;
+  spawn(
+    command: string,
+    args: string[],
+    options: SandboxedSpawnOptions = {},
+  ): SpawnedProcess | Promise<SpawnedProcess> {
+    if (!options.sandbox) {
+      return this.spawnChild(command, args, options);
+    }
+
+    return this.spawnSandboxed(command, args, options, options.sandbox);
+  }
+
+  /**
+   * Spawns a child process inside the OS-level sandbox referenced by the given profile key.
+   *
+   * The profile is resolved, then the sandbox runtime's asynchronous preparation runs: the {@link sandboxCoordinator}
+   * applies the configuration and wraps the command, returning the argv and environment to spawn.
+   *
+   * @param command The command to run.
+   * @param args The arguments to pass to the command.
+   * @param options Options when running the command.
+   * @param sandbox The key of the sandbox profile, under the `causa.sandboxes` configuration, to run the process in.
+   * @returns A promise resolving to a {@link SpawnedProcess}.
+   */
+  private async spawnSandboxed(
+    command: string,
+    args: string[],
+    options: SpawnOptions,
+    sandbox: string,
+  ): Promise<SpawnedProcess> {
+    const config = resolveSandboxProfile(this.context, sandbox);
+    const { argv, environment, release } = await sandboxCoordinator.acquire(
+      config,
+      command,
+      args,
+      options.environment,
+    );
+
+    let childProcess: ChildProcess;
+    let innerResult: Promise<SpawnedProcessResult>;
+    try {
+      ({ childProcess, result: innerResult } = this.spawnChild(
+        argv[0],
+        argv.slice(1),
+        { ...options, environment },
+      ));
+    } catch (error) {
+      release();
+      throw error;
+    }
+
+    const result = innerResult
+      .catch((error) => {
+        // Report failures against the original command/arguments rather than the shell wrapper used to run them.
+        if (error instanceof ProcessServiceExitCodeError) {
+          throw new ProcessServiceExitCodeError(command, args, error.result);
+        }
+
+        throw error;
+      })
+      .finally(release);
+
+    return { childProcess, result };
+  }
+
+  /**
+   * Spawns a child process using {@link spawn} and wires up its standard streams for logging and/or capture.
+   * This is the low-level primitive shared by the regular and sandboxed spawn paths.
+   *
+   * @param command The command to run.
+   * @param args The arguments to pass to the command.
+   * @param options Options when running the command.
+   * @returns A {@link SpawnedProcess}.
+   */
+  private spawnChild(
     command: string,
     args: string[],
     options: SpawnOptions = {},


### PR DESCRIPTION
### 📝 Description of the PR

Adds opt-in OS-level sandboxing for processes spawned through the `ProcessService`, backed by `@anthropic-ai/sandbox-runtime` (macOS Seatbelt / Linux Bubblewrap). Sandbox profiles are declared under `causa.sandboxes` and referenced through the new `sandbox` option of `ProcessService.spawn` (also exposed by `GitService.git` and `DockerService.docker`). A profile can restrict the process's network access to an allowlist of domains, constrain its filesystem reads and writes, and mask or deny environment variables holding credentials — a masked value is replaced by an opaque sentinel inside the sandbox and injected by the host only into the variable's declared hosts. Sandboxing is opt-in: a process runs unsandboxed unless it references a profile, and referencing a missing or invalid profile fails closed rather than running the process unrestricted. Sandboxed commands run one at a time, as the underlying runtime exposes a single sandbox manager per process.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
