### PR TITLE
🐛 Reset the sandbox after every command to avoid hangs on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Reset the OS-level sandbox after every command, fixing a hang on Linux where the CLI would never exit once a sandboxed command completed (the sandbox runtime's network bridges kept the process alive).
+
 ## v1.2.0 (2026-06-29)
 
 Features:

--- a/src/sandbox/coordinator.spec.ts
+++ b/src/sandbox/coordinator.spec.ts
@@ -7,12 +7,8 @@ import 'jest-extended';
 import { SandboxCoordinator, SandboxNotSupportedError } from './coordinator.js';
 
 describe('SandboxCoordinator', () => {
-  const configA: SandboxRuntimeConfig = {
+  const config: SandboxRuntimeConfig = {
     network: { allowedDomains: ['a.example.com'], deniedDomains: [] },
-    filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
-  };
-  const configB: SandboxRuntimeConfig = {
-    network: { allowedDomains: ['b.example.com'], deniedDomains: [] },
     filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
   };
   const configCredentials: SandboxRuntimeConfig = {
@@ -37,11 +33,7 @@ describe('SandboxCoordinator', () => {
       .spyOn(SandboxManager, 'checkDependencies')
       .mockReturnValue({ errors: [], warnings: [] });
     jest.spyOn(SandboxManager, 'initialize').mockResolvedValue(undefined);
-    jest.spyOn(SandboxManager, 'updateConfig').mockReturnValue(undefined);
     jest.spyOn(SandboxManager, 'reset').mockResolvedValue(undefined);
-    jest
-      .spyOn(SandboxManager, 'cleanupAfterCommand')
-      .mockReturnValue(undefined);
     jest
       .spyOn(SandboxManager, 'wrapWithSandboxArgv')
       .mockResolvedValue({ argv: ['/bin/bash', '-c', ':'], env: {} });
@@ -51,17 +43,17 @@ describe('SandboxCoordinator', () => {
 
   afterEach(() => SandboxManager.getSentinelRegistry().clear());
 
-  it('should lazily initialize the manager on the first acquisition', async () => {
+  it('should initialize the manager with the configuration on acquisition', async () => {
     expect(SandboxManager.initialize).not.toHaveBeenCalled();
 
-    await coordinator.acquire(configA, 'node', [], undefined);
+    await coordinator.acquire(config, 'node', [], undefined);
 
-    expect(SandboxManager.initialize).toHaveBeenCalledExactlyOnceWith(configA);
+    expect(SandboxManager.initialize).toHaveBeenCalledExactlyOnceWith(config);
   });
 
   it('should run sandboxed commands one at a time', async () => {
     const { release } = await coordinator.acquire(
-      configA,
+      config,
       'node',
       [],
       undefined,
@@ -69,14 +61,14 @@ describe('SandboxCoordinator', () => {
 
     let secondAcquired = false;
     const second = coordinator
-      .acquire(configA, 'node', [], undefined)
+      .acquire(config, 'node', [], undefined)
       .then(() => {
         secondAcquired = true;
       });
 
     expect(secondAcquired).toBeFalse();
 
-    release();
+    await release();
     await second;
 
     expect(secondAcquired).toBeTrue();
@@ -84,7 +76,7 @@ describe('SandboxCoordinator', () => {
 
   it('should wrap the quoted command and return the spawn-ready argv and merged environment', async () => {
     const { argv, environment, release } = await coordinator.acquire(
-      configA,
+      config,
       'npm',
       ['ci', "a'b"],
       { CALLER: 'x' },
@@ -93,76 +85,37 @@ describe('SandboxCoordinator', () => {
     expect(SandboxManager.wrapWithSandboxArgv).toHaveBeenCalledExactlyOnceWith(
       "'npm' 'ci' 'a'\\''b'",
       undefined,
-      { ...configA, credentials: {} },
+      { ...config, credentials: {} },
     );
     expect(argv).toEqual(['/bin/bash', '-c', ':']);
     expect(environment).toEqual({ CALLER: 'x' });
     expect(release).toBeFunction();
   });
 
-  it('should clean up the per-command artifacts on release', async () => {
+  it('should tear the manager down on release so the process can exit', async () => {
     const { release } = await coordinator.acquire(
-      configA,
-      'node',
-      [],
-      undefined,
-    );
-    release();
-
-    expect(SandboxManager.cleanupAfterCommand).toHaveBeenCalledOnce();
-  });
-
-  it('should reuse the configuration when the next command requests an identical one', async () => {
-    const { release } = await coordinator.acquire(
-      configA,
-      'node',
-      [],
-      undefined,
-    );
-    release();
-
-    await coordinator.acquire(
-      JSON.parse(JSON.stringify(configA)),
+      config,
       'node',
       [],
       undefined,
     );
 
-    expect(SandboxManager.initialize).toHaveBeenCalledOnce();
-    expect(SandboxManager.updateConfig).not.toHaveBeenCalled();
-  });
+    expect(SandboxManager.reset).not.toHaveBeenCalled();
 
-  it('should re-apply the configuration when the next command requests a different one', async () => {
-    const { release } = await coordinator.acquire(
-      configA,
-      'node',
-      [],
-      undefined,
-    );
-    release();
-
-    await coordinator.acquire(configB, 'node', [], undefined);
-
-    expect(SandboxManager.initialize).toHaveBeenCalledOnce();
-    expect(SandboxManager.updateConfig).toHaveBeenCalledExactlyOnceWith(
-      configB,
-    );
-  });
-
-  it('should reinitialize the manager when an initialization-fixed field changes', async () => {
-    const { release } = await coordinator.acquire(
-      configA,
-      'node',
-      [],
-      undefined,
-    );
-    release();
-
-    await coordinator.acquire(configCredentials, 'node', [], undefined);
+    await release();
 
     expect(SandboxManager.reset).toHaveBeenCalledOnce();
+  });
+
+  it('should initialize and tear down the manager for each command', async () => {
+    const first = await coordinator.acquire(config, 'node', [], undefined);
+    await first.release();
+
+    const second = await coordinator.acquire(config, 'node', [], undefined);
+    await second.release();
+
     expect(SandboxManager.initialize).toHaveBeenCalledTimes(2);
-    expect(SandboxManager.updateConfig).not.toHaveBeenCalled();
+    expect(SandboxManager.reset).toHaveBeenCalledTimes(2);
   });
 
   it('should mask declared credentials from the caller environment and strip them from the wrap config', async () => {
@@ -216,7 +169,7 @@ describe('SandboxCoordinator', () => {
     );
     expect(registry.size).toBeGreaterThan(0);
 
-    release();
+    await release();
 
     expect(registry.size).toEqual(0);
   });
@@ -224,7 +177,7 @@ describe('SandboxCoordinator', () => {
   it('should reject when the platform is not supported', async () => {
     jest.spyOn(SandboxManager, 'isSupportedPlatform').mockReturnValue(false);
 
-    const actualPromise = coordinator.acquire(configA, 'node', [], undefined);
+    const actualPromise = coordinator.acquire(config, 'node', [], undefined);
 
     await expect(actualPromise).rejects.toThrow(SandboxNotSupportedError);
     expect(SandboxManager.initialize).not.toHaveBeenCalled();
@@ -235,61 +188,22 @@ describe('SandboxCoordinator', () => {
       .spyOn(SandboxManager, 'checkDependencies')
       .mockReturnValue({ errors: ['ripgrep (rg) not found'], warnings: [] });
 
-    const actualPromise = coordinator.acquire(configA, 'node', [], undefined);
+    const actualPromise = coordinator.acquire(config, 'node', [], undefined);
 
     await expect(actualPromise).rejects.toThrow(SandboxNotSupportedError);
     expect(SandboxManager.initialize).not.toHaveBeenCalled();
   });
 
-  it('should release the hold so the next command can run when applying the configuration fails', async () => {
+  it('should release the hold so the next command can run when initialization fails', async () => {
     jest
       .spyOn(SandboxManager, 'initialize')
       .mockRejectedValueOnce(new Error('💥'));
 
     await expect(
-      coordinator.acquire(configA, 'node', [], undefined),
+      coordinator.acquire(config, 'node', [], undefined),
     ).rejects.toThrow('💥');
 
-    await coordinator.acquire(configA, 'node', [], undefined);
-    expect(SandboxManager.initialize).toHaveBeenCalledTimes(2);
-  });
-
-  it('should wait for the running command to release before resetting', async () => {
-    const { release } = await coordinator.acquire(
-      configA,
-      'node',
-      [],
-      undefined,
-    );
-
-    let didReset = false;
-    const resetPromise = coordinator.reset().then(() => {
-      didReset = true;
-    });
-
-    expect(didReset).toBeFalse();
-    expect(SandboxManager.reset).not.toHaveBeenCalled();
-
-    release();
-    await resetPromise;
-
-    expect(didReset).toBeTrue();
-    expect(SandboxManager.reset).toHaveBeenCalledOnce();
-  });
-
-  it('should tear down the manager and allow re-initialization on reset', async () => {
-    const { release } = await coordinator.acquire(
-      configA,
-      'node',
-      [],
-      undefined,
-    );
-    release();
-    await coordinator.reset();
-
-    expect(SandboxManager.reset).toHaveBeenCalledOnce();
-
-    await coordinator.acquire(configA, 'node', [], undefined);
+    await coordinator.acquire(config, 'node', [], undefined);
     expect(SandboxManager.initialize).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/sandbox/coordinator.ts
+++ b/src/sandbox/coordinator.ts
@@ -2,7 +2,6 @@ import {
   SandboxManager,
   type SandboxRuntimeConfig,
 } from '@anthropic-ai/sandbox-runtime';
-import { isDeepStrictEqual } from 'util';
 import { mergeSandboxEnvironment } from './environment.js';
 
 /**
@@ -26,33 +25,19 @@ export type AcquiredSandboxCommand = {
   readonly environment: Record<string, string | undefined>;
 
   /**
-   * Cleans up the command's per-command artifacts and releases the serialization lock so the next command can run.
-   * Must be called once the command has finished (or failed to start). Idempotent.
+   * Tears the sandbox down and releases the serialization lock so the next command can run.
+   * Must be called (and awaited) once the command has finished (or failed to start). Idempotent.
    */
-  readonly release: () => void;
+  readonly release: () => Promise<void>;
 };
 
 /**
  * Coordinates access to the process-wide `SandboxManager` singleton.
  *
- * The sandbox runtime exposes a single manager per process.
- * Sandboxed commands are therefore run strictly one at a time. As the only optimization, the global configuration is
- * reused as-is (not re-applied) when a command requests the exact same one as the previous command.
- *
- * Teardown is handled by the sandbox runtime itself: `SandboxManager.initialize()` registers `exit`/`SIGINT`/`SIGTERM`
- * handlers that call its own `reset()`.
+ * The sandbox runtime exposes a single manager per process, so sandboxed commands are run strictly one at a time: each
+ * command initializes the manager with its own configuration, runs, then tears it down on release.
  */
 export class SandboxCoordinator {
-  /**
-   * The configuration currently applied to the manager, or `undefined` if none has been applied yet.
-   */
-  private activeConfig: SandboxRuntimeConfig | undefined;
-
-  /**
-   * Whether `SandboxManager.initialize()` has been called (and the proxies started) in this process.
-   */
-  private initialized = false;
-
   /**
    * Whether the platform/dependency support check has already passed.
    */
@@ -66,11 +51,11 @@ export class SandboxCoordinator {
 
   /**
    * Acquires the exclusive right to run a sandboxed command and prepares it: waits for the previous command to release,
-   * applies the configuration, and wraps the command for execution inside the sandbox. The returned argv and
-   * environment are ready to be spawned.
+   * initializes the manager with the configuration, and wraps the command for execution inside the sandbox. The
+   * returned argv and environment are ready to be spawned.
    *
-   * Each successful call returns a `release` function that must be called once the command has finished (or failed to
-   * start) to clean up its per-command artifacts and let the next command run.
+   * Each successful call returns a `release` function that must be called and awaited once the command has finished
+   * (or failed to start) to tear the sandbox down and let the next command run.
    *
    * @param config The configuration the command requires.
    * @param command The command to run.
@@ -86,10 +71,10 @@ export class SandboxCoordinator {
   ): Promise<AcquiredSandboxCommand> {
     this.ensureSupported();
 
-    const releaseLock = await this.lock();
+    const release = await this.lock();
 
     try {
-      await this.applyConfig(config);
+      await SandboxManager.initialize(config);
 
       const commandString = [command, ...args]
         .map((token) => `'${token.replaceAll("'", `'\\''`)}'`)
@@ -104,10 +89,9 @@ export class SandboxCoordinator {
       const env = mergeSandboxEnvironment(environment, sbxEnv);
       this.applyCredentials(config, environment, env);
 
-      const release = this.makeRelease(releaseLock);
       return { argv, environment: env, release };
     } catch (error) {
-      releaseLock();
+      await release();
       throw error;
     }
   }
@@ -146,80 +130,31 @@ export class SandboxCoordinator {
   }
 
   /**
-   * Builds the `release` function returned by {@link SandboxCoordinator.acquire}. It cleans up the per-command sandbox
-   * artifacts (e.g. Linux bwrap mount points) and frees the serialization lock. It is idempotent.
+   * Takes the serialization lock, resolving once the previously-acquired command has released.
    *
-   * @param releaseLock The function freeing the serialization lock.
-   * @returns The `release` function.
+   * @returns An idempotent `release` function that tears the manager down and frees the lock so the next holder can
+   *   proceed.
    */
-  private makeRelease(releaseLock: () => void): () => void {
+  private async lock(): Promise<() => Promise<void>> {
+    const previous = this.tail;
+    let releaseLock!: () => void;
+    this.tail = new Promise<void>((resolve) => (releaseLock = resolve));
+    await previous;
+
     let released = false;
-    return () => {
+    return async () => {
       if (released) {
         return;
       }
       released = true;
 
-      SandboxManager.cleanupAfterCommand();
-      SandboxManager.getSentinelRegistry().clear();
-      releaseLock();
+      try {
+        SandboxManager.getSentinelRegistry().clear();
+        await SandboxManager.reset();
+      } finally {
+        releaseLock();
+      }
     };
-  }
-
-  /**
-   * Takes the serialization lock, resolving once the previous holder (a command or a {@link SandboxCoordinator.reset})
-   * has released. The returned function must be called to release the lock and let the next holder proceed.
-   *
-   * @returns The function releasing the lock.
-   */
-  private async lock(): Promise<() => void> {
-    const previous = this.tail;
-    let release!: () => void;
-    this.tail = new Promise<void>((resolve) => (release = resolve));
-    await previous;
-    return release;
-  }
-
-  /**
-   * Applies a configuration to the manager.
-   *
-   * - Identical to the active one: reused as-is.
-   * - Differing only in the live-updatable network allow/deny lists: applied with `updateConfig`.
-   * - Differing in an initialization-fixed field (e.g. TLS termination): the manager is torn down and re-initialized.
-   *
-   * @param config The configuration to apply.
-   */
-  private async applyConfig(config: SandboxRuntimeConfig): Promise<void> {
-    const active = this.activeConfig;
-    if (this.initialized && active) {
-      if (isDeepStrictEqual(config, active)) {
-        return;
-      }
-
-      // Only the network allow/deny lists are live-updatable. `tlsTerminate` (the mitm CA) and the presence of
-      // `credentials` (which wires the credential injector) are fixed at initialization, so a change in either requires
-      // tearing the manager down.
-      const requiresReinitialization =
-        (config.credentials === undefined) !==
-          (active.credentials === undefined) ||
-        !isDeepStrictEqual(
-          config.network.tlsTerminate,
-          active.network.tlsTerminate,
-        );
-
-      if (!requiresReinitialization) {
-        SandboxManager.updateConfig(config);
-        this.activeConfig = config;
-        return;
-      }
-
-      await SandboxManager.reset();
-      this.initialized = false;
-    }
-
-    await SandboxManager.initialize(config);
-    this.initialized = true;
-    this.activeConfig = config;
   }
 
   /**
@@ -246,25 +181,6 @@ export class SandboxCoordinator {
     }
 
     this.supportChecked = true;
-  }
-
-  /**
-   * Tears down the manager and resets the coordinator's state.
-   * Mostly useful for tests and explicit shutdowns. In normal CLI usage the sandbox runtime resets itself on process
-   * exit.
-   */
-  async reset(): Promise<void> {
-    const release = await this.lock();
-
-    try {
-      this.activeConfig = undefined;
-      this.initialized = false;
-      this.supportChecked = false;
-
-      await SandboxManager.reset();
-    } finally {
-      release();
-    }
   }
 }
 

--- a/src/services/process.spec.ts
+++ b/src/services/process.spec.ts
@@ -6,7 +6,6 @@ import 'jest-extended';
 import { dirname } from 'path';
 import type { Logger } from 'pino';
 import { fileURLToPath } from 'url';
-import { sandboxCoordinator } from '../sandbox/coordinator.js';
 import { SandboxProfileNotFoundError } from '../sandbox/profile.js';
 import { ProcessService, ProcessServiceExitCodeError } from './process.js';
 
@@ -134,14 +133,8 @@ describe('ProcessService', () => {
         .spyOn(SandboxManager, 'checkDependencies')
         .mockReturnValue({ errors: [], warnings: [] });
       jest.spyOn(SandboxManager, 'initialize').mockResolvedValue(undefined);
-      jest.spyOn(SandboxManager, 'updateConfig').mockReturnValue(undefined);
       jest.spyOn(SandboxManager, 'reset').mockResolvedValue(undefined);
-      jest
-        .spyOn(SandboxManager, 'cleanupAfterCommand')
-        .mockReturnValue(undefined);
     });
-
-    afterEach(() => sandboxCoordinator.reset());
 
     function mockPassthroughWrapping() {
       jest
@@ -193,7 +186,7 @@ describe('ProcessService', () => {
           credentials: {},
         },
       );
-      expect(SandboxManager.cleanupAfterCommand).toHaveBeenCalledOnce();
+      expect(SandboxManager.reset).toHaveBeenCalledOnce();
     });
 
     it('should reject rather than run unsandboxed when the sandbox key is not configured', async () => {

--- a/src/services/process.ts
+++ b/src/services/process.ts
@@ -232,7 +232,7 @@ export class ProcessService {
         { ...options, environment },
       ));
     } catch (error) {
-      release();
+      await release();
       throw error;
     }
 


### PR DESCRIPTION
### 📝 Description of the PR

Fixes a hang on Linux where the Causa CLI never exited after a sandboxed command (e.g. `npm ci` run inside a configured sandbox) completed successfully. The OS-level sandbox is now torn down after each command in the coordinator's own control flow, rather than relying on the sandbox runtime's process-exit handler — which an embedder that never calls `process.exit` cannot reach, because the runtime's network-bridge child processes keep the Node event loop alive. macOS, which already exited cleanly, is unaffected, and interrupting a running command still tears the sandbox down.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
