### PR TITLE
🔖 Prepare v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.2.1 (2026-06-29)
+
 Fixes:
 
 - Reset the OS-level sandbox after every command, fixing a hang on Linux where the CLI would never exit once a sandboxed command completed (the sandbox runtime's network bridges kept the process alive).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-core",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.61",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The Causa workspace module providing core function definitions and some implementations.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Reset the OS-level sandbox after every command, fixing a hang on Linux where the CLI would never exit once a sandboxed command completed (the sandbox runtime's network bridges kept the process alive).